### PR TITLE
Maven Build Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,3 +33,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }
+apply from: '../gradle-mvn-push.gradle'
+

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AeroGear Android SDK
+POM_ARTIFACT_ID=core
+POM_PACKAGING=aar

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013 Chris Banes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'maven'
+apply plugin: 'signing'
+apply plugin: 'com.github.dcendents.android-maven'
+
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
+group = POM_GROUP_ID
+project.archivesBaseName = POM_ARTIFACT_ID
+version = VERSION_NAME
+
+afterEvaluate { project ->
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                pom.groupId = POM_GROUP_ID
+                pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
+
+                repository(url: getReleaseRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+                snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+
+                pom.project {
+                    name POM_NAME
+                    packaging POM_PACKAGING
+                    description POM_DESCRIPTION
+                    url POM_URL
+
+                    scm {
+                        url POM_SCM_URL
+                        connection POM_SCM_CONNECTION
+                        developerConnection POM_SCM_DEV_CONNECTION
+                    }
+
+                    licenses {
+                        license {
+                            name POM_LICENCE_NAME
+                            url POM_LICENCE_URL
+                            distribution POM_LICENCE_DIST
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id POM_DEVELOPER_ID
+                            name POM_DEVELOPER_NAME
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        sign configurations.archives
+    }
+
+    android.libraryVariants.all { variant ->
+        def javadocTask = task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
+            description "Generates Javadoc for $variant.name."
+            source = variant.javaCompile.source
+            ext.androidJar = project.files(android.getBootClasspath().join(File.pathSeparator))
+            classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+            exclude '**/BuildConfig.java'
+            exclude '**/R.java'
+        }
+
+        javadocTask.dependsOn variant.javaCompile
+
+        def jarJavadocTask = task("jar${variant.name.capitalize()}Javadoc", type: Jar) {
+            description "Generate Javadoc Jar for $variant.name"
+            classifier = 'javadoc'
+            from javadocTask.destinationDir
+        }
+
+        jarJavadocTask.dependsOn javadocTask
+        artifacts.add('archives', jarJavadocTask)
+
+        def jarSourceTask = task("jar${variant.name.capitalize()}Sources", type: Jar) {
+            description "Generates Java Sources for $variant.name."
+            classifier = 'sources'
+            from variant.javaCompile.source
+        }
+
+        jarSourceTask.dependsOn variant.javaCompile
+        artifacts.add('archives', jarSourceTask)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,22 @@
-# Project-wide Gradle settings.
+# Android Stuff
 
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
+VERSION_CODE=500
+VERSION_NAME=5.0.0-SNAPSHOT
 
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Bintray Stuff
 
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+REPO_NAME=aerogear-android-sdk
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# Maven Stuff
+
+POM_GROUP_ID=org.aerogear
+POM_DESCRIPTION=AeroGear Android SDK
+POM_URL=http://aerogear.org
+POM_SCM_URL=https://github.com/aerogear/aerogear-android-sdk
+POM_SCM_CONNECTION=scm:git@github.com:aerogear/aerogear-android-sdk.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:aerogear/aerogear-android-sdk.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=aerogear
+POM_DEVELOPER_NAME=aerogear

--- a/keycloak-service-module/build.gradle
+++ b/keycloak-service-module/build.gradle
@@ -31,3 +31,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     compile project(path: ':core')
 }
+
+apply from: '../gradle-mvn-push.gradle'

--- a/keycloak-service-module/gradle.properties
+++ b/keycloak-service-module/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AeroGear Android SDK
+POM_ARTIFACT_ID=keycloak-module
+POM_PACKAGING=aar


### PR DESCRIPTION
This PR adds the ability to generate maven artifacts to the core SDK.

# How to Test

from the root of the repository you should run `./gradlew install`.  The build should complete without errors and you should have in your loval maven repository (ex ~/.m2/repository) two new artifacts: "org.aerogear.core" and "org.aerogear.keycloak-module".

This PR includes bits from #4, but once that is merged this can be rebased and merged.