### PR TITLE
Agdroid 693 parse mobile core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion project.ext.targetSdkVersion
 
-    defaultConfig {
+   defaultConfig {
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
 
@@ -12,6 +12,13 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
+    sourceSets {
+        test {
+            assets.srcDirs = ["src/test/assets"]
+        }
+    }
+
 
     buildTypes {
         release {
@@ -24,14 +31,24 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    testImplementation "org.robolectric:robolectric:3.6.1"
+
+    testImplementation 'com.android.support.test:runner:1.0.1'
+    testImplementation 'com.android.support.test:rules:1.0.1'
+    testImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }
 apply from: '../gradle-mvn-push.gradle'
 

--- a/core/src/debug/assets/mobile-core.json
+++ b/core/src/debug/assets/mobile-core.json
@@ -1,0 +1,46 @@
+{
+  "services": [
+    {
+      "config": {
+        "headers": {},
+        "uri": "https://fh-sync-server-myproject.192.168.37.1.nip.io"
+      },
+      "name": "fh-sync-server"
+    },
+    {
+      "config": {
+        "auth-server-url": "http://keycloak-myproject.192.168.37.1.nip.io/auth",
+        "clientId": "OeFYkwEuUKXvDsSudfXc",
+        "headers": {},
+        "realm": "myproject",
+        "resource": "OeFYkwEuUKXvDsSudfXc",
+        "ssl-required": "external",
+        "url": "http://keycloak-myproject.192.168.37.1.nip.io/auth"
+      },
+      "name": "keycloak"
+    },
+    {
+      "config": {
+        "headers": {},
+        "name": "prometheus",
+        "type": "prometheus",
+        "uri": "https://prometheus-myproject.192.168.37.1.nip.io"
+      },
+      "name": "prometheus"
+    },
+    {
+      "config": {
+        "headers": {},
+        "mysql_db": "unifiedpush",
+        "mysql_password": "unifiedpush",
+        "mysql_username": "unifiedpush",
+        "name": "unified-push-server",
+        "push_kc_realm": "aerogear",
+        "type": "unified-push-server",
+        "uri": "http://ups-myproject.192.168.37.1.nip.io"
+      },
+      "name": "unified-push-server"
+    }
+  ],
+  "namespace": "myproject"
+}

--- a/core/src/debug/assets/mobile-services.json
+++ b/core/src/debug/assets/mobile-services.json
@@ -1,0 +1,46 @@
+{
+  "services": [
+    {
+      "config": {
+        "headers": {},
+        "uri": "https://fh-sync-server-myproject.192.168.37.1.nip.io"
+      },
+      "name": "fh-sync-server"
+    },
+    {
+      "config": {
+        "auth-server-url": "http://keycloak-myproject.192.168.37.1.nip.io/auth",
+        "clientId": "OeFYkwEuUKXvDsSudfXc",
+        "headers": {},
+        "realm": "myproject",
+        "resource": "OeFYkwEuUKXvDsSudfXc",
+        "ssl-required": "external",
+        "url": "http://keycloak-myproject.192.168.37.1.nip.io/auth"
+      },
+      "name": "keycloak"
+    },
+    {
+      "config": {
+        "headers": {},
+        "name": "prometheus",
+        "type": "prometheus",
+        "uri": "https://prometheus-myproject.192.168.37.1.nip.io"
+      },
+      "name": "prometheus"
+    },
+    {
+      "config": {
+        "headers": {},
+        "mysql_db": "unifiedpush",
+        "mysql_password": "unifiedpush",
+        "mysql_username": "unifiedpush",
+        "name": "unified-push-server",
+        "push_kc_realm": "aerogear",
+        "type": "unified-push-server",
+        "uri": "http://ups-myproject.192.168.37.1.nip.io"
+      },
+      "name": "unified-push-server"
+    }
+  ],
+  "namespace": "myproject"
+}

--- a/core/src/main/java/org/aerogear/mobile/core/BootstrapException.java
+++ b/core/src/main/java/org/aerogear/mobile/core/BootstrapException.java
@@ -1,0 +1,10 @@
+package org.aerogear.mobile.core;
+
+/**
+ * This is an unchecked exception that is thrown when bootstrapping a module fails.
+ */
+class BootstrapException extends RuntimeException {
+    public BootstrapException(String message, Throwable rootException) {
+        super(message, rootException);
+    }
+}

--- a/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
+++ b/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
@@ -1,37 +1,103 @@
 package org.aerogear.mobile.core;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.JsonReader;
 import android.util.Log;
 
+import org.aerogear.mobile.core.configuration.MobileCoreJsonParser;
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 import org.aerogear.mobile.core.logging.Logger;
+import org.json.JSONException;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+/**
+ * MobileCore is the entry point into AeroGear mobile services that are managed by the mobile-core
+ * ¿feature( TODO: Get correct noun )? in OpenShift.
+ * <p>
+ * Usage.java
+ * ```
+ * MobileCore core = new MobileCore.Builder(context, R.raw.mobile_core).build();
+ * core.feature(Keycloak.class).login();// would begin a OAuth flow.
+ * core.feature(MyRestService.class).upload(myData);// Would upload myData and be secured by KeyCloak
+ * ```
+ */
 public final class MobileCore implements ServiceModule {
 
 
-    private MobileCore() {
+    private final Context context;
 
+    private Map<String, ServiceConfiguration> configurationMap;
+
+    private MobileCore(@NonNull Context conext) {
+        this.context = conext.getApplicationContext();
     }
 
-    public static Logger defaultLog() {
+    public Logger defaultLog() {
         return (String message, Exception e) -> {
             Log.e("MOBILE_CORE", message, e);
         };
     }
 
-
     @Override
     public void bootstrap(Object... args) {
-        for (Object object : args) {
-            if (object instanceof Class) {
-                try {
-                    Object instance = ((Class)object).newInstance();
-                    if (instance instanceof ServiceModule) {
 
-                    }
-                } catch (InstantiationException | IllegalAccessException e) {
-                    e.printStackTrace();
-                    throw new RuntimeException(e);
-                }
+
+        try (InputStream configStream = context.getAssets().open("mobile-core.json");) {
+            this.configurationMap = MobileCoreJsonParser.parse(configStream);
+        } catch (JSONException | IOException e) {
+            defaultLog().error(e.getMessage(), e);
+            throw new BootstrapException("mobile-core.json could not be loaded", e);
+        }
+
+
+        //startup known modules
+    }
+
+    public ServiceConfiguration getConfig(String configurationName) {
+        return configurationMap.get(configurationName);
+    }
+
+    /**
+     * Builder for MobileCore.  This class ensures that required properties are set and then creates
+     * a MobileCore instance.
+     * <p>
+     * Usage.java
+     * ```
+     * MobileCore core = new MobileCore.Builder(context, R.raw.mobile_core).build();
+     * ```
+     */
+    public static class Builder {
+
+        private final Context context;
+        private boolean built = false;
+
+        public Builder(@NonNull Context context) {
+            this.context = context;
+        }
+
+
+        /**
+         * Builds a mobile core instance.  Please note that once this is built the Builder may not
+         * be used again.
+         *
+         * @return a mobile core instance based on Builder parameters
+         * @throws IllegalStateException if this builder has already been built.
+         */
+        public MobileCore build() {
+            if (!built) {
+                built = true;
+                MobileCore core = new MobileCore(context);
+                core.bootstrap();
+                return core;
+            } else {
+                throw new IllegalStateException("MobileCore has already been built");
             }
         }
     }
+
 }

--- a/core/src/main/java/org/aerogear/mobile/core/ServiceModule.java
+++ b/core/src/main/java/org/aerogear/mobile/core/ServiceModule.java
@@ -2,5 +2,10 @@ package org.aerogear.mobile.core;
 
 public interface ServiceModule {
 
+    /**
+     * This is the method called by mobile-core to startup modules.
+     * @param args any data that a module would need to start up
+     * @throws BootstrapException if bootstrapping fails.
+     */
     void bootstrap(Object... args);
 }

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
@@ -1,0 +1,103 @@
+package org.aerogear.mobile.core.configuration;
+
+import android.util.JsonReader;
+import android.util.JsonToken;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * This class is responsible for consuming a reader and producing a tree of config values to be
+ * consumed by modules.
+ */
+public class MobileCoreJsonParser {
+
+    private TreeMap<String, ServiceConfiguration> values = new TreeMap<>();
+
+    private MobileCoreJsonParser(InputStream jsonStream) throws IOException, JSONException {
+        String jsonText = readJsonStream(jsonStream);
+        JSONObject jsonDocument = new JSONObject(jsonText);
+        parseMobileCoreArray(jsonDocument.getJSONArray("services"));
+    }
+
+    private String readJsonStream(InputStream jsonStream) throws IOException {
+        String out = "";
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(jsonStream))) {
+            StringBuilder builder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line).append('\n');
+            }
+            out = builder.toString();
+        }
+        return out;
+    }
+
+    private void parseMobileCoreArray(JSONArray array) throws JSONException, IOException {
+        int length = array.length();
+        for (int i = 0; i < length; i++) {
+            parseConfigObject(array.getJSONObject(i));
+        }
+    }
+
+    private void parseConfigObject(JSONObject object) throws JSONException, IOException {
+        ServiceConfiguration serviceConfig = new ServiceConfiguration();
+        serviceConfig.setName(object.getString("name"));
+        JSONObject config = object.getJSONObject("config");
+        JSONArray namesArray = config.names();
+        int namesSize = namesArray.length();
+        for (int i = 0; i < namesSize; i++) {
+            String name = namesArray.getString(i);
+            switch (name) {
+                case "type":
+                    serviceConfig.setType(config.getString("type"));
+                case "uri":
+                    serviceConfig.setUri(config.getString("uri"));
+                case "headers":
+                    addHeaders(serviceConfig, config.getJSONObject("headers"));
+                default:
+                    serviceConfig.addProperty(name, config.getString(name));
+            }
+        }
+
+        values.put(serviceConfig.getName(), serviceConfig);
+
+    }
+
+    private void addHeaders(ServiceConfiguration serviceConfig, JSONObject headers) throws JSONException {
+        JSONArray headerNames = headers.names();
+
+        if (headerNames == null) {
+            return;
+        }
+
+        int namesSize = headerNames.length();
+        for (int i = 0; i < namesSize; i++) {
+            String headerName = headerNames.getString(i);
+            serviceConfig.addHeader(headerName, headers.getString(headerName));
+        }
+    }
+
+    /**
+     * @param jsonStream a inputStream to for mobile-core.json.  Please note that this
+     *                   should be managed by the calling core.  The parser will not close the resource
+     *                   when it is finished.
+     *
+     * @return A map of Servicconfigs mapped by their name.
+     * @throws IOException   if reading the stream fails
+     * @throws JSONException if the json document is malformed
+     */
+    public static Map<String, ServiceConfiguration> parse(InputStream jsonStream) throws IOException, JSONException {
+        MobileCoreJsonParser parser = new MobileCoreJsonParser(jsonStream);
+        return parser.values;
+    }
+}

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/ServiceConfiguration.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/ServiceConfiguration.java
@@ -1,0 +1,61 @@
+package org.aerogear.mobile.core.configuration;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This represents a parsed service from the mobilce-config.json
+ */
+public class ServiceConfiguration {
+    private String name;
+    private HashMap<String, String> properties = new HashMap<>();
+    private String type;
+    private String uri;
+    private HashMap<String, String> headers = new HashMap<>();
+
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void addProperty(String name, String value) {
+        properties.put(name, value);
+    }
+
+    public Map<String, String> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    public String getProperty(String name) {
+        return properties.get(name);
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void addHeader(String headerName, String headerValue) {
+        headers.put(headerName, headerValue);
+    }
+
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+}

--- a/core/src/test/AndroidManifest.xml
+++ b/core/src/test/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.aerogear.android.core" />

--- a/core/src/test/java/org/aerogear/mobile/core/MobileCoreParserTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/MobileCoreParserTest.java
@@ -32,7 +32,31 @@ public class MobileCoreParserTest {
         Assert.assertNull(core.getConfig("null"));
     }
 
+    @Test
+    public void testConfigurableMobileServiceFileName() throws IOException {
+        Application application = RuntimeEnvironment.application;
+        MobileCore.Builder builder = new MobileCore.Builder(application)
+                                            .setMobileServiceFileName("mobile-core.json");
+        MobileCore core = builder.build();
+        Assert.assertNotNull(core.getConfig("prometheus"));
+        ServiceConfiguration config = core.getConfig("keycloak");
+        org.junit.Assert.assertEquals("http://keycloak-myproject.192.168.37.1.nip.io/auth", config.getProperty("auth-server-url"));
+        Assert.assertNull(core.getConfig("null"));
+    }
 
+    @Test(expected = BootstrapException.class)
+    public void testMobileConfigBootstrapExceptionFileNotFound() throws IOException {
+        Application application = RuntimeEnvironment.application;
+        MobileCore.Builder builder = new MobileCore.Builder(application)
+                .setMobileServiceFileName("mobile-co2re.json");
+        try {
+            MobileCore core = builder.build();
+        } catch (BootstrapException exception) {
+            org.junit.Assert.assertEquals("mobile-co2re.json could not be loaded", exception.getMessage());
+            throw exception;
+        }
+
+    }
 
 }
 

--- a/core/src/test/java/org/aerogear/mobile/core/MobileCoreParserTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/MobileCoreParserTest.java
@@ -1,0 +1,38 @@
+package org.aerogear.mobile.core;
+
+import android.app.Application;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
+import org.aerogear.android.core.R;
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@RunWith(RobolectricTestRunner.class)
+@SmallTest
+public class MobileCoreParserTest {
+
+    @Test
+    public void testAssetMobileCoreParsing() throws IOException {
+        Application application = RuntimeEnvironment.application;
+        MobileCore.Builder builder = new MobileCore.Builder(application);
+        MobileCore core = builder.build();
+        Assert.assertNotNull(core.getConfig("prometheus"));
+        ServiceConfiguration config = core.getConfig("keycloak");
+        org.junit.Assert.assertEquals("http://keycloak-myproject.192.168.37.1.nip.io/auth", config.getProperty("auth-server-url"));
+        Assert.assertNull(core.getConfig("null"));
+    }
+
+
+
+}
+

--- a/keycloak-service-module/src/main/java/org/aerogear/mobile/keycloak_service_module/KeyCloakService.java
+++ b/keycloak-service-module/src/main/java/org/aerogear/mobile/keycloak_service_module/KeyCloakService.java
@@ -34,7 +34,7 @@ public class KeyCloakService implements ServiceModule {
               JsonReader reader = new JsonReader(new InputStreamReader(keycloakConfigStream, "UTF-8") ) ) {
             config = KeyCloakConfig.parse(reader);
         } catch (IOException e) {
-            MobileCore.defaultLog().error(e.getMessage(), e);
+            //MobileCore.defaultLog().error(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
This add support for parsing a mobile-core.json file from the mobile cli tool.

# How to test

run `./gradlew testDebug` from the project root.  You should see in your gradle logs that the parsing tests for the example mobile-core.json file are run.

#Notes
This depends on PRs #4 and #5   Should we make changes to those we will need to rebase this PR.