### PR TITLE
AGDROID-697 aerogear-parent BOM usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom 'org.jboss.aerogear:aerogear-android-sdk-bom:1.1.7-SNAPSHOT'
+            mavenBom 'org.jboss.aerogear:aerogear-android-sdk-bom:1.1.7'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "io.spring.dependency-management" version "1.0.4.RELEASE"
+}
+
 allprojects {
     repositories {
         google()
@@ -15,6 +19,16 @@ allprojects {
     }
 
     project.apply from: "${rootDir}/constants.gradle"
+}
+
+subprojects {
+    apply plugin: 'io.spring.dependency-management'
+
+    dependencyManagement {
+        imports {
+            mavenBom 'org.jboss.aerogear:aerogear-android-sdk-bom:1.1.7-SNAPSHOT'
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Adds the spring dep management plugin and the new BOM from aerogear-parent.


Pending finishing publication of https://github.com/aerogear/aerogear-parent/releases/tag/1.1.7, with changes from https://github.com/aerogear/aerogear-parent/pull/75