### PR TITLE
AGDROID-686 - Add Token Verification [Do No Merge]

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'net.openid:appauth:0.7.0'
     testImplementation 'org.mockito:mockito-core:2.10.0'
     testImplementation 'junit:junit:4.12'
+    compile 'org.bitbucket.b_c:jose4j:0.6.3'
 }
 
 sourceCompatibility = "1.7"

--- a/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
@@ -94,12 +94,12 @@ public class OIDCCredentials implements ICredential {
             //  Validate the JWT and process it to the Claims
             JwtClaims jwtClaims = jwtConsumer.processToClaims(jwtToken);
             verified = true;
-            System.out.println("JWT validation succeeded! " + jwtClaims);
+            System.out.println("JWT Verified Successfully.");
         }
         catch (InvalidJwtException e)
         {
             // InvalidJwtException will be thrown, if the JWT failed processing or validation in anyway.
-            System.out.println("Invalid JWT! " + e);
+            System.out.println("JWT Validation Failed. " + e.getLocalizedMessage());
 
         }
         return verified;

--- a/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
@@ -4,6 +4,17 @@ import net.openid.appauth.AuthState;
 
 import org.aerogear.auth.AuthenticationException;
 import org.json.JSONException;
+import org.jose4j.jwa.AlgorithmConstraints;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.keys.RsaKeyUtil;
+import org.jose4j.lang.JoseException;
+
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
 
 /**
  * Credentials for OIDC based authentication
@@ -30,6 +41,68 @@ public class OIDCCredentials implements ICredential {
 
     public String getRefreshToken() {
         return authState.getRefreshToken();
+    }
+
+    /**
+     * A function to verify the authenticity of a JWT token against a public key, expected issuer and audience.
+     * @param jwtToken - The JWT Token to Verify.
+     * @param publicKey - The Public Key from Keycloak, without the Begin/End tags.
+     * @param issuer - The expected Issuer of the JWT
+     * @param audience - The expected Audience of the JWT
+     * @return boolean - true if the token integrity is good
+     */
+    public boolean verifyToken(String jwtToken, String publicKey, String issuer, String audience) {
+
+        // TODO Get the Public Key from the Mobile Core Config
+        // TODO Get the Audience from the Mobile Core Config
+        // TODO Construct the Issuer using properties in the Mobile Core Config
+
+        boolean verified = false;
+
+        // add the Begin/End tags to the public key generated from Keycloak
+        String beginPublicKey = "-----BEGIN PUBLIC KEY-----";
+        String endPublicKey = "-----END PUBLIC KEY-----";
+        String constructedPublicKey = beginPublicKey + publicKey + endPublicKey;
+
+        // Convert the public key from a string to a Java security key
+        RsaKeyUtil utils = new RsaKeyUtil();
+        PublicKey jwtPublicKey = null;
+        try {
+            jwtPublicKey = utils.fromPemEncoded(constructedPublicKey);
+        } catch (JoseException e) {
+            e.printStackTrace();
+        } catch (InvalidKeySpecException e) {
+            e.printStackTrace();
+        }
+
+
+        // Validate and process the JWT.
+        JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+                .setRequireExpirationTime() // require the JWT to have an expiration time
+                .setAllowedClockSkewInSeconds(30) // allow some leeway in validating time based claims to account for clock skew
+                .setRequireSubject() // require the subject claim
+                .setExpectedIssuer(issuer) // whom the JWT needs to have been issued by
+                .setExpectedAudience(audience) // to whom the JWT is intended for
+                .setVerificationKey(jwtPublicKey) // verify the signature with the public key
+                .setJwsAlgorithmConstraints( // only allow the expected signature algorithm(s) in the given context
+                        new AlgorithmConstraints(AlgorithmConstraints.ConstraintType.WHITELIST, // which is only RS256 here
+                                AlgorithmIdentifiers.RSA_USING_SHA256))
+                .build(); // create the JwtConsumer instance
+
+        try
+        {
+            //  Validate the JWT and process it to the Claims
+            JwtClaims jwtClaims = jwtConsumer.processToClaims(jwtToken);
+            verified = true;
+            System.out.println("JWT validation succeeded! " + jwtClaims);
+        }
+        catch (InvalidJwtException e)
+        {
+            // InvalidJwtException will be thrown, if the JWT failed processing or validation in anyway.
+            System.out.println("Invalid JWT! " + e);
+
+        }
+        return verified;
     }
 
     /**

--- a/auth/src/test/java/org/aerogear/auth/credentials/OIDCCredentialsTest.java
+++ b/auth/src/test/java/org/aerogear/auth/credentials/OIDCCredentialsTest.java
@@ -1,0 +1,125 @@
+package org.aerogear.auth.credentials;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Created by tjackman on 22/01/18.
+ */
+
+public class OIDCCredentialsTest {
+
+    private final String VALID_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkr1fDOUrTZc1MnpY9brGiA7Cz6X1nX77pmrUEgnMq2mxU7ibSW0CAk5e5a4wkmLGYf8EyvaFPHT1fMrFmDK03oN8Q2anh+3e894cXBXazHzzaJD+Lz1HfOOZFeInkAasxWSo8KN1+Kg+1Z7QyrPLhfcbIwfH2Stabx+3lfEMtPGws7tqWg93piA8is1PwIV5/8k4CqLe7jNtUyYS4BKR07oBY6VVxXOKKQAQ3ToLN++sjfaXAjDuE1Go7iW9q7Yt6q9qu4JCX+k6IWu68y/H6cicLXwS1VXPMwFjDOj7cQZB7A3t4q0F+6NVL+t7UjrAAK/7V3lPB+rDwHO92iwlZwIDAQAB";
+    private final String INVALID_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh86f89U+DJkuCaxFUATgiQS4TWx/kyY1xSDOWKPMVddL2mT4H44tcMf2A/aYJnFJL24zg42f3nt8hHnX4o2O0zlh1T7E60riCtKVn2BT4hBQXMMhUhVmNL8RHP5s4X3WFBN9q/yLisXLHYJ9OCnsah4ZFQOAbwiqVNpY7+tVt2uw6pUrMhy65Dj6jspn96t6p/HCI1ZdCQwzRdlCx77ZOQywNTqKU9W4DibG3WU7DPmgHbrpCJjHCvK/+cMRtTx6lhH8W/cHVN8D5FZUiC61eEFPGwV5wa7KqrKsJE23YUCxemb36xV21zBXay/j1vSxhIGB6d6G+ckI0FkanfrMmQIDAQAB";
+    private final String INVALID_PUBLIC_KEY_FORMAT = "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkr1fDOUrTZc1MnpY9brGiA7Cz6X1nX77pmrUEgnMq2mxU7ibSW0CAk5e5a4wkmLGYf8EyvaFPHT1fMrFmDK03oN8Q2anh+3e894cXBXazHzzaJD+Lz1HfOOZFeInkAasxWSo8KN1+Kg+1Z7QyrPLhfcbIwfH2Stabx+3lfEMtPGws7tqWg93piA8is1PwIV5/8k4CqLe7jNtUyYS4BKR07oBY6VVxXOKKQAQ3ToLN++sjfaXAjDuE1Go7iW9q7Yt6q9qu4JCX+k6IWu68y/H6cicLXwS1VXPMwFjDOj7cQZB7A3t4q0F+6NVL+t7UjrAAK/7V3lPB+rDwHO92iwlZwIDAQAB-----END PUBLIC KEY-----";
+
+    private final String VALID_ISSUER = "https://keycloak.security.feedhenry.org/auth/realms/secure-app";
+    private final String VALID_AUDIENCE = "client-app";
+
+    private final String INVALID_ISSUER = "https://invalid.com/issuer";
+    private final String INVALID_AUDIENCE = "invalid-audience";
+
+    private final String EXPIRED_ACCESS_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiJkMWVmMWIyMS00OTVlLTRjYjMtYmQzNS1mMTM5YzcxNGFlOWIiLCJleHAiOjE1MTY2MjA5MzgsIm5iZiI6MCwiaWF0IjoxNTE2NjIwNjM4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3VyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJjbGllbnQtYXBwIiwiYXV0aF90aW1lIjoxNTE2NjIwNjM3LCJzZXNzaW9uX3N0YXRlIjoiODg0MzZjMTAtNjQ3Yy00OTM4LTgwZmYtODAzMTBhYjc1NTNhIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJtb2JpbGUtdXNlciJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImNsaWVudC1hcHAiOnsicm9sZXMiOlsiaW9zLWFjY2VzcyJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwibmFtZSI6IlVzZXIgMSIsInByZWZlcnJlZF91c2VybmFtZSI6InVzZXIxIiwiZ2l2ZW5fbmFtZSI6IlVzZXIiLCJmYW1pbHlfbmFtZSI6IjEiLCJlbWFpbCI6InVzZXIxQGZlZWRoZW5yeS5vcmcifQ.Hy7mII0Z4d70jcZJTvDeIRi_tZPp7k5qID-c94XmpTUrCT7YJkWjV158oq5iG2bs-RdHSdmUYSCc2ZrUMWAUmsdVxUe621oLzI50csqW3iXQfEO4urUYYFHIknkqP76PIdwFW80zMANCeiXMZEy8D4iJ_UkzDoo872w4iCNApZVnFxk2S15WbyPQPiXbSaMjLkZsEiKKjzfacDtPtSpgbtq9s5DuU7QrBvkmGZYofY94-gORglXpu3KIhs4oXmk2-2CTDqsOpV-eS1OyeZQ080Xfr5N9X7Rfe-fvTToTuFiuMOPOpzgkYDUuCU7Tcymp7EXjpBf2YX65m3QtYY9SYA";
+
+    // WARNING: Tokens Expire on 10/01/2031 @ 2:50pm (UTC)
+    private final String VALID_REFRESH_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiIwMGJhODRlYy01MTYzLTRhZDgtYWNmMC04ZTQ2Mzc4OWE0MmUiLCJleHAiOjE5NDg2MzI2NDgsIm5iZiI6MCwiaWF0IjoxNTE2NjMyNjQ4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3VyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoiY2xpZW50LWFwcCIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6ImMyNTVmMGFjLTgwOTEtNGM5Mi04ZjNhLTQ4ZmZiODgxYTcwYiIsInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJtb2JpbGUtdXNlciJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImNsaWVudC1hcHAiOnsicm9sZXMiOlsiaW9zLWFjY2VzcyJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fX0.Df_B_o7xaVyF6yGzyjfZJLwF6J9jrmjlzkKGtWyBzblBFVs8HMNWhUen3QJIq_lJLEloXKMh0Hfd5Yo0iPbLlNFXb_qIuIUUDtHuQHEL5-LZbTW8WCvotbfVbO9hTHxXJXs5sWdL3wcS1T5PuC5l6mP1a1fppvkWPOlcRFWVy9f-aBSRiUNGoN_AlL2FUIeFeHKeyfw7F5EndQt9HRfoFr0vD1VuB7uM2UWhnscCwsFWZ2AMz_ZoiUQPjtUm-y3UMURFcAhIYHCw7xI1tPRVdMkMC8i87Qq9HJ90eflEDjqse6x67m48kT1wvI2qhoexPa-ALdWMrseWIdRqBmSUHw";
+    private final String VALID_IDENTITY_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiIzMmJjMjc4Yy00MmUyLTQwMjctOWVkZi1mZTM3OTcxYjkyZTQiLCJleHAiOjE5NDg2MzI2NDgsIm5iZiI6MCwiaWF0IjoxNTE2NjMyNjQ4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3VyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJJRCIsImF6cCI6ImNsaWVudC1hcHAiLCJhdXRoX3RpbWUiOjE1MTY2MzI2NDcsInNlc3Npb25fc3RhdGUiOiJjMjU1ZjBhYy04MDkxLTRjOTItOGYzYS00OGZmYjg4MWE3MGIiLCJhY3IiOiIxIiwibmFtZSI6IlVzZXIgMSIsInByZWZlcnJlZF91c2VybmFtZSI6InVzZXIxIiwiZ2l2ZW5fbmFtZSI6IlVzZXIiLCJmYW1pbHlfbmFtZSI6IjEiLCJlbWFpbCI6InVzZXIxQGZlZWRoZW5yeS5vcmcifQ.h_WzsxdBUG0eBMz_zgEyl0yOMlVJ1YkNTRaiWje7Do3s90URP3y_nFkz9NNMSfoADPLZdTWe9fWL1h2LWfc6WUmasr4hx9zks76Asz78rZLyC4ARuGSwUncCiLxdB4chq-SAOoXYiZV6K0St-UhBkV90jd6xc5WIKrTItqDenuMjkc5ePU7Sx9MYE2fS4dKGNdRGff8uAXELpM66eVxM6xn-xBTEuHPQvR-vFoFLUssxMVk8IjsAb2H9epioWshQkY0vL70z58egAqiLVluVFecRXmsrLGrVnRx-S3UjQRKLyo_V3CyFCfGKspGtsXZYhmzzmMTdqPU_wLax59A69w";
+    private final String VALID_ACCESS_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiJlMzkzOGU2Zi0zOGQzLTQ2MmYtYTg1OS04YjNiODA0N2NlNzkiLCJleHAiOjE5NDg2MzI2NDgsIm5iZiI6MCwiaWF0IjoxNTE2NjMyNjQ4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3VyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJjbGllbnQtYXBwIiwiYXV0aF90aW1lIjoxNTE2NjMyNjQ3LCJzZXNzaW9uX3N0YXRlIjoiYzI1NWYwYWMtODA5MS00YzkyLThmM2EtNDhmZmI4ODFhNzBiIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJtb2JpbGUtdXNlciJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImNsaWVudC1hcHAiOnsicm9sZXMiOlsiaW9zLWFjY2VzcyJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwibmFtZSI6IlVzZXIgMSIsInByZWZlcnJlZF91c2VybmFtZSI6InVzZXIxIiwiZ2l2ZW5fbmFtZSI6IlVzZXIiLCJmYW1pbHlfbmFtZSI6IjEiLCJlbWFpbCI6InVzZXIxQGZlZWRoZW5yeS5vcmcifQ.RvsLrOrLB3EFkZvYZM8-QXf6rRllCap-embNwa2V-NTMpcR7EKNMkKUQI9MbBlVSkTEBckZAK0DGSdo5CYuFoFH-xVWkzU0yQKBuFYAK1Etd50yQWwS1vHiThT95ZgeGGCB3ptafY5UCoqyg41kKqO5rb8iGyZ3ACp2xoEOE5S1rPAPszcQrbKBryOOk7H6MDZgqhZxxGUJkDVAT2v3jAd1aJ4K17qH6raabtDrAy_541vn6c0LS1ay0ooW4IVFzjFSH1-jMJvCYM6oku7brPonl2qHO8jMLrrhxylw2VXIAlregih6aNJ5c87729UtEJNTEFyqGI6GCunt2DQt7cw";
+
+    private final String TAMPERED_REFRESH_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiIwMGJhODRlYy01MTYzLTRhZDgtYWNmMC04ZTQ2Mzc4OWE0MmUiLCJleHAiOjE5NDg2MzI2NDgsIm5iZiI6MCwiaWF0IjoxNTE2NjMyNjQ4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3cyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoiY2xpZW50LWFwcCIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6ImMyNTVmMGFjLTgwOTEtNGM5Mi04ZjNhLTQ4ZmZiODgxYTcwYiIsInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJtb2JpbGUtdXNlciJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImNsaWVudC1hcHAiOnsicm9sZXMiOlsiaW9zLWFjY2VzcyJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fX0.Df_B_o7xaVyF6yGzyjfZJLwF6J9jrmjlzkKGtWyBzblBFVs8HMNWhUen3QJIq_lJLEloXKMh0Hfd5Yo0iPbLlNFXb_qIuIUUDtHuQHEL5-LZbTW8WCvotbfVbO9hTHxXJXs5sWdL3wcS1T5PuC5l6mP1a1fppvkWPOlcRFWVy9f-aBSRiUNGoN_AlL2FUIeFeHKeyfw7F5EndQt9HRfoFr0vD1VuB7uM2UWhnscCwsFWZ2AMz_ZoiUQPjtUm-y3UMURFcAhIYHCw7xI1tPRVdMkMC8i87Qq9HJ90eflEDjqse6x67m48kT1wvI2qhoexPa-ALdWMrseWIdRqBmSUHw\n";
+    private final String TAMPERED_IDENTITY_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiIzMmJjMjc4Yy00MmUyLTQwMjctOWVkZi1mZTM3OTcxYjkyZTQiLCJleHAiOjE5NDg2MzI2NDgsIm5iZiI6MCwiaWF0IjoxNTE2NjMyNjQ4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3VyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJJRCIsImF6cCI6ImNsaWVudC1hcHAiLCJhdXRoX3RpbWUiOjE1MTY2MzI2NDcsInNlc3Npb25fc3RhdGUiOiJjMjU1ZjBhYy04MDkxLTRjOTItOGYzYS00OGZmYjg4MWE3MGIiLCJhY3IiOiIxIiwibmFtZSI6IlVzZXIgMSIsInByZWZlcnJlZF91c2VybmFtZSI6InVzZXIxIiwiZ2l2ZW5fbmFtZSI6IlVzZXIiLCJmYW1pbHlfbmFtZSI6IjEiLCJlbWFpbCI6InVzZsIxQGZlZWRoZW5yeS5vcmcifQ.h_WzsxdBUG0eBMz_zgEyl0yOMlVJ1YkNTRaiWje7Do3s90URP3y_nFkz9NNMSfoADPLZdTWe9fWL1h2LWfc6WUmasr4hx9zks76Asz78rZLyC4ARuGSwUncCiLxdB4chq-SAOoXYiZV6K0St-UhBkV90jd6xc5WIKrTItqDenuMjkc5ePU7Sx9MYE2fS4dKGNdRGff8uAXELpM66eVxM6xn-xBTEuHPQvR-vFoFLUssxMVk8IjsAb2H9epioWshQkY0vL70z58egAqiLVluVFecRXmsrLGrVnRx-S3UjQRKLyo_V3CyFCfGKspGtsXZYhmzzmMTdqPU_wLax59A69w\n";
+    private final String TAMPERED_ACCESS_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJhZFNveVhOQWdReFY0M2VxSFNpUlpmNmhOOXl0dkJOUXliMmZGU2RDVFZNIn0.eyJqdGkiOiJlMzkzOGU2Zi0zOGQzLTQ2MmYtYTg1OS04YjNiODA0N2NlNzkiLCJleHAiOjE5NDg2MzI2NDgsIm5iZiI6MCwiaWF0IjoxNTE2NjMyNjQ4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnNlY3VyaXR5LmZlZWRoZW5yeS5vcmcvYXV0aC9yZWFsbXMvc2VjdXJlLWFwcCIsImF1ZCI6ImNsaWVudC1hcHAiLCJzdWIiOiJiMTYxN2UzOC0zODczLTRhNDctOGE2Yy01YjgyMmFkYTI3NWUiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJjbGllbnQtYXBwIiwiYXV0aF90aW1lIjoxNTE2NjMyNjQ3LCJzZXNzaW9uX3N0YXRlIjoiYzI1NWYwYWMtODA5MS00YzkyLThmM2EtNDhmZmI4ODFhNzBiIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJtb2JpbGUtdXNlciJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImNsaWVtdC1hcHAiOnsicm9sZXMiOlsiaW9zLWFjY2VzcyJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNub3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwibmFtZSI6IlVzZXIgMSIsInByZWZlcnJlZF91c2VybmFtZSI6InVzZXIxIiwiZ2l2ZW5fbmFtZSI6IlVzZXIiLCJmYW1pbHlfbmFtZSI6IjEiLCJlbWFpbCI6InVzZXIxQGZlZWRoZW5yeS5vcmcifQ.RvsLrOrLB3EFkZvYZM8-QXf6rRllCap-embNwa2V-NTMpcR7EKNMkKUQI9MbBlVSkTEBckZAK0DGSdo5CYuFoFH-xVWkzU0yQKBuFYAK1Etd50yQWwS1vHiThT95ZgeGGCB3ptafY5UCoqyg41kKqO5rb8iGyZ3ACp2xoEOE5S1rPAPszcQrbKBryOOk7H6MDZgqhZxxGUJkDVAT2v3jAd1aJ4K17qH6raabtDrAy_541vn6c0LS1ay0ooW4IVFzjFSH1-jMJvCYM6oku7brPonl2qHO8jMLrrhxylw2VXIAlregih6aNJ5c87729UtEJNTEFyqGI6GCunt2DQt7cw\n";
+
+    @Before
+    public void setup() {
+
+    }
+
+    @Test
+    public void testValidPublicKey() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertTrue("Expect Token Validation with Correct Public Key to Succeed", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testInvalidPublicKey() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Wrong Public Key to Fail", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, INVALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testInvalidPublicKeyFormat() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Wrong Public Key Format to Fail", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, INVALID_PUBLIC_KEY_FORMAT, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testValidAudience() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertTrue("Expect Token Validation with Valid Audience to Succeed", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testInvalidAudience() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Wrong Audience to Fail", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, INVALID_AUDIENCE));
+    }
+
+    @Test
+    public void testValidIssuer() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertTrue("Expect Token Validation with Valid Issuer to Succeed", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testInvalidIssuer() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Wrong Issuer to Fail", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, VALID_PUBLIC_KEY, INVALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testExpiredExpirationTime() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Expired Time to Fail", oidcCredentials.verifyToken(EXPIRED_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testValidAccessToken() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertTrue("Expect Token Validation with Valid Access Token to Succeed", oidcCredentials.verifyToken(VALID_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testTamperedAccessToken() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Tampered Access Token to Fail", oidcCredentials.verifyToken(TAMPERED_ACCESS_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testValidIdentityToken() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertTrue("Expect Token Validation with Valid Identity Token to Succeed", oidcCredentials.verifyToken(VALID_IDENTITY_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testTamperedIdentityToken() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Tampered Identity Token to Fail", oidcCredentials.verifyToken(TAMPERED_IDENTITY_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testValidRefreshToken() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertTrue("Expect Token Validation with Valid Refresh Token to Succeed", oidcCredentials.verifyToken(VALID_REFRESH_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+    @Test
+    public void testTamperedRefreshToken() {
+        OIDCCredentials oidcCredentials = new OIDCCredentials();
+        assertFalse("Expect Token Validation with Tampered Refresh Token to Fail", oidcCredentials.verifyToken(TAMPERED_REFRESH_TOKEN, VALID_PUBLIC_KEY, VALID_ISSUER, VALID_AUDIENCE));
+    }
+
+}


### PR DESCRIPTION
**Description**
[Do Not Merge]
Function to Verify JWT Tokens (Access, Identity, Refresh) using a Keycloak Realm Public Key before they are used as part of client side access control decisions.

Tested successfully with both valid & tampered Access/Identity tokens. Identity Brokering originated tokens can also be validated.

**To Do**
- [ ] Get the Public Key from the Mobile Core Config (when available)
- [ ] Get the Audience from the Mobile Core Config (when available)
- [ ]  Construct the Issuer using properties in the Mobile Core Config (when available)
- [x]  Add Unit tests - Test Wrong issues, audiences, tampered signature, payload, algorithm info sections etc