### PR TITLE
AGDROID-682 Include checkAuthStatus

### DIFF
--- a/auth/src/main/java/org/aerogear/auth/IUserPrincipal.java
+++ b/auth/src/main/java/org/aerogear/auth/IUserPrincipal.java
@@ -35,4 +35,6 @@ public interface IUserPrincipal extends Principal {
      * @return the credentials that authenticate this users
      */
     ICredential getCredentials();
+
+    boolean checkValidAuth();
 }

--- a/auth/src/main/java/org/aerogear/auth/IUserPrincipal.java
+++ b/auth/src/main/java/org/aerogear/auth/IUserPrincipal.java
@@ -35,6 +35,4 @@ public interface IUserPrincipal extends Principal {
      * @return the credentials that authenticate this users
      */
     ICredential getCredentials();
-
-    boolean checkValidAuth();
 }

--- a/auth/src/main/java/org/aerogear/auth/credentials/ICredential.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/ICredential.java
@@ -5,27 +5,4 @@ package org.aerogear.auth.credentials;
  */
 public interface ICredential {
 
-    /**
-     * Check whether credential needs to be renewed
-     * @return <code>true</code> if the credential needs to be renewed
-     */
-    boolean getNeedsRenewal();
-
-    /**
-     * Set the credential to be renewed whether it needs to or not.
-     * This is a way to force the renewal of the credential.
-     */
-    void setNeedsRenewal();
-
-    /**
-     * Check whether the credential is authenticated/authorized.
-     * @return <code>true</code> if the credential is authorized.
-     */
-    boolean isAuthorized();
-
-    /**
-     * Check whether the credential is invalid in any way (expired, invalid).
-     * @return <code>true</code> if the credential is valid and usable.
-     */
-    boolean checkValidAuth();
 }

--- a/auth/src/main/java/org/aerogear/auth/credentials/ICredential.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/ICredential.java
@@ -4,4 +4,9 @@ package org.aerogear.auth.credentials;
  * Base interface for credential objects.
  */
 public interface ICredential {
+
+    boolean getNeedsTokenRefresh();
+    void setNeedsTokenRefresh();
+    boolean isAuthorized();
+
 }

--- a/auth/src/main/java/org/aerogear/auth/credentials/ICredential.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/ICredential.java
@@ -5,8 +5,27 @@ package org.aerogear.auth.credentials;
  */
 public interface ICredential {
 
-    boolean getNeedsTokenRefresh();
-    void setNeedsTokenRefresh();
+    /**
+     * Check whether credential needs to be renewed
+     * @return <code>true</code> if the credential needs to be renewed
+     */
+    boolean getNeedsRenewal();
+
+    /**
+     * Set the credential to be renewed whether it needs to or not.
+     * This is a way to force the renewal of the credential.
+     */
+    void setNeedsRenewal();
+
+    /**
+     * Check whether the credential is authenticated/authorized.
+     * @return <code>true</code> if the credential is authorized.
+     */
     boolean isAuthorized();
 
+    /**
+     * Check whether the credential is invalid in any way (expired, invalid).
+     * @return <code>true</code> if the credential is valid and usable.
+     */
+    boolean checkValidAuth();
 }

--- a/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
@@ -44,14 +44,14 @@ public class OIDCCredentials implements ICredential {
      * Check whether new access token is needed.
      * @return <code>true</code> if access token is needed
      */
-    public boolean getNeedsTokenRefresh() {
+    public boolean getNeedsRenewal() {
         return authState.getNeedsTokenRefresh();
     }
 
     /**
      * Force request of new access token.
      */
-    public void setNeedsTokenRefresh() {
+    public void setNeedsRenewal() {
         authState.setNeedsTokenRefresh(true);
     }
 
@@ -72,11 +72,19 @@ public class OIDCCredentials implements ICredential {
     }
 
     /**
-     * Refresh the token
+     * Check whether the user is authorized and not expired.
+     * @return <code>true</code> if user is authorized and token is not expired.
+     */
+    public boolean checkValidAuth() {
+        return isAuthorized() && getNeedsRenewal();
+    }
+
+    /**
+     * Renew the token
      * @return
      * @throws AuthenticationException
      */
-    public boolean refresh() throws AuthenticationException {
+    public boolean renew() throws AuthenticationException {
         throw new IllegalStateException("Not yet implemented");
     }
 }

--- a/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
+++ b/auth/src/main/java/org/aerogear/auth/credentials/OIDCCredentials.java
@@ -37,7 +37,30 @@ public class OIDCCredentials implements ICredential {
      * @return <code>true</code> if expired.
      */
     public boolean isExpired() {
-        throw new IllegalStateException("Not yet implemented");
+        return authState.hasClientSecretExpired();
+    }
+
+    /**
+     * Check whether new access token is needed.
+     * @return <code>true</code> if access token is needed
+     */
+    public boolean getNeedsTokenRefresh() {
+        return authState.getNeedsTokenRefresh();
+    }
+
+    /**
+     * Force request of new access token.
+     */
+    public void setNeedsTokenRefresh() {
+        authState.setNeedsTokenRefresh(true);
+    }
+
+    /**
+     * Check if the user is authenticated/authorized.
+     * @return <code>true</code> if the user is authenticated/authorized.
+     */
+    public boolean isAuthorized() {
+        return authState.isAuthorized();
     }
 
     /**
@@ -49,11 +72,11 @@ public class OIDCCredentials implements ICredential {
     }
 
     /**
-     * Renew the token
+     * Refresh the token
      * @return
      * @throws AuthenticationException
      */
-    public boolean renew() throws AuthenticationException {
+    public boolean refresh() throws AuthenticationException {
         throw new IllegalStateException("Not yet implemented");
     }
 }

--- a/auth/src/main/java/org/aerogear/auth/impl/OIDCUserPrincipalImpl.java
+++ b/auth/src/main/java/org/aerogear/auth/impl/OIDCUserPrincipalImpl.java
@@ -1,0 +1,45 @@
+package org.aerogear.auth.impl;
+
+import org.aerogear.auth.AbstractAuthenticator;
+import org.aerogear.auth.IRole;
+import org.aerogear.auth.credentials.OIDCCredentials;
+
+import java.util.Map;
+
+public class OIDCUserPrincipalImpl extends UserPrincipalImpl {
+
+    /**
+     * Builds a new UserPrincipalImpl object
+     *
+     * @param username the username of the authenticated user
+     * @param credentials the OIDC credentials of the user
+     * @param email the email of the authenticated user
+     * @param roles roles assigned to the user
+     * @param authenticator the authenticator that authenticated this user
+     */
+    protected OIDCUserPrincipalImpl(final String username,
+                             final OIDCCredentials credentials,
+                             final String email,
+                             final Map<String, IRole> roles,
+                             final AbstractAuthenticator authenticator) {
+        super(username, credentials, email, roles, authenticator);
+    }
+
+    static class Builder extends UserPrincipalImpl.Builder {
+        private Builder() {
+            super();
+        }
+
+        @Override
+        OIDCUserPrincipalImpl build() {
+            return new OIDCUserPrincipalImpl(
+                    this.username,
+                    (OIDCCredentials) this.credentials,
+                    this.email,
+                    this.roles,
+                    this.authenticator);
+        }
+    }
+
+    public static Builder newUser() { return new Builder(); }
+}

--- a/auth/src/main/java/org/aerogear/auth/impl/UserPrincipalImpl.java
+++ b/auth/src/main/java/org/aerogear/auth/impl/UserPrincipalImpl.java
@@ -44,7 +44,7 @@ public class UserPrincipalImpl extends AbstractPrincipal {
      * @param roles roles assigned to the user
      * @param authenticator the authenticator that authenticated this user
      */
-    private UserPrincipalImpl(final String username,
+    protected UserPrincipalImpl(final String username,
                               final ICredential credentials,
                               final String email,
                               final Map<String, IRole> roles,
@@ -60,13 +60,13 @@ public class UserPrincipalImpl extends AbstractPrincipal {
      * Builds and return a UserPrincipalImpl object
      */
     static class Builder {
-        private String username;
-        private String email;
-        private Map<String, IRole> roles = new HashMap<>();
-        private AbstractAuthenticator authenticator;
+        protected String username;
+        protected String email;
+        protected Map<String, IRole> roles = new HashMap<>();
+        protected AbstractAuthenticator authenticator;
         protected ICredential credentials;
 
-        private Builder() {
+        protected Builder() {
         }
 
         Builder withUsername(final String username) {

--- a/auth/src/main/java/org/aerogear/auth/impl/UserPrincipalImpl.java
+++ b/auth/src/main/java/org/aerogear/auth/impl/UserPrincipalImpl.java
@@ -137,15 +137,6 @@ public class UserPrincipalImpl extends AbstractPrincipal {
         return username;
     }
 
-    /**
-     * Check whether the user is authorized and not expired.
-     * @return <code>true</code> if user is authorized and token is not expired.
-     */
-    @Override
-    public boolean checkValidAuth() {
-        return getCredentials().isAuthorized() && !getCredentials().getNeedsTokenRefresh();
-    }
-
     @Override
     public Collection<IRole> getRoles() {
         return roles.values();

--- a/auth/src/main/java/org/aerogear/auth/impl/UserPrincipalImpl.java
+++ b/auth/src/main/java/org/aerogear/auth/impl/UserPrincipalImpl.java
@@ -137,6 +137,14 @@ public class UserPrincipalImpl extends AbstractPrincipal {
         return username;
     }
 
+    /**
+     * Check whether the user is authorized and not expired.
+     * @return <code>true</code> if user is authorized and token is not expired.
+     */
+    @Override
+    public boolean checkValidAuth() {
+        return getCredentials().isAuthorized() && !getCredentials().getNeedsTokenRefresh();
+    }
 
     @Override
     public Collection<IRole> getRoles() {


### PR DESCRIPTION
## Motivation

Allow checking for current auth status. Both is authorized and token isn't expired.

JIRA: https://issues.jboss.org/browse/AGDROID-682

## Description

Wraps AuthState some more with OIDCCredentials, mainly wrapping `isAuthorized()` and `getNeedsTokenRefresh()`.

Check these to determine the current auth state using `checkAuthState()`.

## Progress

- [x] Check if authorized
- [x] Check if needs refresh (is expired)
- [x] Unit tests (Everything is a thin wrapper around AppAuth Android)
