### PR TITLE
fix parsing for mobile config

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
@@ -56,10 +56,13 @@ public class MobileCoreJsonParser {
             switch (name) {
                 case "type":
                     serviceConfigBuilder.setType(config.getString("type"));
+                    break;
                 case "uri":
                     serviceConfigBuilder.setUri(config.getString("uri"));
+                    break;
                 case "headers":
                     addHeaders(serviceConfigBuilder, config.getJSONObject("headers"));
+                    break;
                 default:
                     serviceConfigBuilder.addProperty(name, config.getString(name));
             }


### PR DESCRIPTION
## Motivation

This should fix some problems with parsing mobile-services.json. Or was the fallthrough intended for some reason?

## Additional Notes

Tested with the following mobile-services.json file:

```
{
  "services": [
    {
      "config": {
        "headers": {
          "User-Agent": "AeroGear Android Core"
        },
        "url": "http://http-myproject.192.168.37.1.nip.io"
      },
      "name": "http"
    },
    {
      "config": {
        "uri": "https://www.mocky.io/v2/5185415ba171ea3a00704eed"
      },
      "name": "metrics"
    }
  ],
  "namespace": "myproject"
}
```
