### PR TITLE
AGDROID-671 - Create API documentation for the Android IDM SDK

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -30,14 +30,6 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
-
-    task generateAuthJavadoc(type: Javadoc, group: "Documentation"){
-        description = 'Generates Auth Javadoc from auth/src/main dir'
-        source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        destinationDir = file("../docs/auth/javadoc/")
-        failOnError false
-    }
 }
 
 dependencies {
@@ -48,3 +40,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.robolectric:robolectric'
 }
+
+apply from: '../gradle-mvn-push.gradle'

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -31,7 +31,8 @@ android {
         unitTests.includeAndroidResources = true
     }
 
-    task generateAuthJavadoc(type: Javadoc){
+    task generateAuthJavadoc(type: Javadoc, group: "Documentation"){
+        description = 'Generates Auth Javadoc from auth/src/main dir'
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
         destinationDir = file("../docs/auth/javadoc/")

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -30,6 +30,13 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
+
+    task generateAuthJavadoc(type: Javadoc){
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        destinationDir = file("../docs/auth/javadoc/")
+        failOnError false
+    }
 }
 
 dependencies {

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AeroGear Android SDK
+POM_ARTIFACT_ID=auth
+POM_PACKAGING=aar


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AGDROID-671

## Description

A gradle task was added to the auth module, so we could easily generate API documentation for the Android IDM SDK for developer reference.

## Progress

- [x] Add Gradle Task
- [ ] Optional Todo - Extend task to parent build.gradle to be used by all modules 

## Additional Notes

To run task 
```
$ ./gradlew -q generateAuthJavadoc
```
The docs will be generated and stored in `docs/auth/javadoc`
