### PR TITLE
Agdroid 730

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -34,9 +34,14 @@ android {
 
 dependencies {
     implementation project(path: ':core')
+    implementation project(path: ':metrics')
+
     implementation 'net.openid:appauth'
     implementation 'org.bitbucket.b_c:jose4j'
+
     testImplementation "junit:junit"
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.robolectric:robolectric'
 }
+
+apply from: '../gradle-mvn-push.gradle'

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AeroGear Android SDK
+POM_ARTIFACT_ID=auth
+POM_PACKAGING=aar

--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -8,12 +8,15 @@ import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
 import org.aerogear.mobile.auth.authenticator.OIDCAuthenticateOptions;
 import org.aerogear.mobile.auth.credentials.OIDCCredentials;
 import org.aerogear.mobile.auth.authenticator.OIDCAuthenticatorImpl;
+import org.aerogear.mobile.auth.metrics.AuthMetricsProvider;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.utils.UserIdentityParser;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.ServiceModule;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 import org.aerogear.mobile.core.logging.Logger;
+import org.aerogear.mobile.metrics.MetricsRegistry;
+import org.aerogear.mobile.metrics.MetricsService;
 
 import java.security.Principal;
 
@@ -106,6 +109,7 @@ public class AuthService implements ServiceModule {
         this.authStateManager = AuthStateManager.getInstance(context);
         this.authServiceConfiguration = authServiceConfiguration;
         this.oidcAuthenticatorImpl = new OIDCAuthenticatorImpl(this.serviceConfiguration, this.authServiceConfiguration, this.appContext, this.authStateManager);
+        MetricsRegistry.instance().registerProvider(new AuthMetricsProvider());
     }
 
     @Override

--- a/auth/src/main/java/org/aerogear/mobile/auth/metrics/AuthMetricsProvider.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/metrics/AuthMetricsProvider.java
@@ -1,0 +1,21 @@
+package org.aerogear.mobile.auth.metrics;
+
+import android.content.Context;
+
+import org.aerogear.mobile.metrics.interfaces.MetricsProvider;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class AuthMetricsProvider extends MetricsProvider {
+    @Override
+    public String namespace() {
+        return "auth";
+    }
+
+    @Override
+    public JSONObject metrics(Context context) throws JSONException {
+        JSONObject metrics = new JSONObject();
+        // TODO: add metrics
+        return metrics;
+    }
+}

--- a/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
+++ b/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
@@ -1,5 +1,6 @@
 package org.aerogear.mobile.core;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
@@ -27,7 +28,6 @@ public final class MobileCore {
 
     private static Logger logger = new LoggerAdapter();
 
-    private final String appVersion;
     private final String configFileName;
     private final HttpServiceModule httpLayer;
     private final Map<String, ServiceConfiguration> servicesConfig;
@@ -53,9 +53,6 @@ public final class MobileCore {
             String message = String.format("%s could not be loaded", configFileName);
             throw new InitializationException(message, exception);
         }
-
-        // -- Set the app version variable
-        this.appVersion = getAppVersion(context);
 
         // -- Setting default http layer
         if (options.httpServiceModule == null) {
@@ -152,24 +149,6 @@ public final class MobileCore {
         return serviceConfiguration;
     }
 
-    /**
-     * Get the user app version from the package manager
-     *
-     * @param context Android application context
-     * @return String app version name
-     */
-    private String getAppVersion(final Context context) throws InitializationException {
-        try {
-            return context
-                .getPackageManager()
-                .getPackageInfo(context.getPackageName(), 0)
-                .versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            // Wrap in Initialization exception
-            throw new InitializationException("Failed to read app version", e);
-        }
-    }
-
     public HttpServiceModule getHttpLayer() {
         return this.httpLayer;
     }
@@ -185,15 +164,6 @@ public final class MobileCore {
      */
     public static String getSdkVersion() {
         return BuildConfig.VERSION_NAME;
-    }
-
-    /**
-     * Get the version of the user app
-     *
-     * @return String App version name
-     */
-    public String getAppVersion() {
-        return appVersion;
     }
 
     public static final class Options {

--- a/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
@@ -21,6 +21,8 @@ public interface HttpResponse {
     HttpResponse onComplete(Runnable runnable);
 
     int getStatus();
+    boolean isFailed();
+    Exception getRequestError();
 
     /**
      * This is a terminal method that will block the thread called on until the http request has been

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
@@ -61,6 +61,16 @@ class OkHttpResponse implements HttpResponse {
     }
 
     @Override
+    public boolean isFailed() {
+        return requestError != null;
+    }
+
+    @Override
+    public Exception getRequestError() {
+        return requestError;
+    }
+
+    @Override
     public void waitForCompletionAndClose() {
         try {
             requestCompleteLatch.await(DEFAULT_TIMEOUT, TimeUnit.SECONDS);

--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -28,7 +28,6 @@ android {
 
 dependencies {
     implementation project(path: ':core')
-
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.json:json'

--- a/metrics/src/main/java/org/aerogear/mobile/metrics/MetricsRegistry.java
+++ b/metrics/src/main/java/org/aerogear/mobile/metrics/MetricsRegistry.java
@@ -1,0 +1,35 @@
+package org.aerogear.mobile.metrics;
+
+import org.aerogear.mobile.metrics.interfaces.MetricsProvider;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The metrics registry is the central storage for all metrics providers
+ */
+public final class MetricsRegistry {
+    private static MetricsRegistry INSTANCE;
+
+    private final Set<MetricsProvider> providers = new HashSet<>();
+
+    private MetricsRegistry() {
+        INSTANCE = this;
+    }
+
+    public void registerProvider(MetricsProvider provider) {
+        providers.add(provider);
+    }
+
+    public Set<MetricsProvider> getProviders() {
+        return this.providers;
+    }
+
+    public static MetricsRegistry instance() {
+        if (INSTANCE == null) {
+            new MetricsRegistry();
+        }
+
+        return INSTANCE;
+    }
+}

--- a/metrics/src/main/java/org/aerogear/mobile/metrics/MetricsService.java
+++ b/metrics/src/main/java/org/aerogear/mobile/metrics/MetricsService.java
@@ -16,6 +16,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class MetricsService implements ServiceModule {
+    public final static String STORAGE_NAME = "org.aerogear.mobile.metrics";
+    public final static String STORAGE_KEY = "metrics-sdk-installation-id";
+
     private final static String MODULE_NAME = "metrics";
     public final static String TAG = "AEROGEAR/METRICS";
 

--- a/metrics/src/main/java/org/aerogear/mobile/metrics/interfaces/MetricsProvider.java
+++ b/metrics/src/main/java/org/aerogear/mobile/metrics/interfaces/MetricsProvider.java
@@ -1,0 +1,40 @@
+package org.aerogear.mobile.metrics.interfaces;
+
+import android.content.Context;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Objects;
+
+public abstract class MetricsProvider {
+    public String namespace() {
+        return null;
+    }
+
+    public JSONObject metrics(final Context context) throws JSONException {
+        return new JSONObject();
+    }
+
+    @Override
+    public int hashCode() {
+        if (namespace() == null) {
+            return 0;
+        }
+
+        // Two providers with the same namespace are considered equal
+        return namespace().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (getClass() != o.getClass())
+            return false;
+        MetricsProvider person = (MetricsProvider) o;
+        return Objects.equals(namespace(), person.namespace());
+    }
+}

--- a/metrics/src/main/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProvider.java
+++ b/metrics/src/main/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProvider.java
@@ -1,0 +1,82 @@
+package org.aerogear.mobile.metrics.providers;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.metrics.MetricsService;
+import org.aerogear.mobile.metrics.interfaces.MetricsProvider;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.UUID;
+
+public class DefaultMetricsProvider extends MetricsProvider {
+    public final static String STORAGE_NAME = "org.aerogear.mobile.metrics";
+    public final static String STORAGE_KEY = "metrics-sdk-installation-id";
+
+    /**
+     * Get or create the client ID that identifies a device as long as the user doesn't
+     * reinstall the app or delete the app storage. A random UUID is created and stored in the
+     * application shared preferences.
+     *
+     * Can be overridden to provide a different implementation for identification.
+     *
+     * @param context Android app context
+     * @return String Client ID
+     */
+    protected String getOrCreateClientId(final Context context) {
+        final SharedPreferences preferences = context
+            .getSharedPreferences(STORAGE_NAME, Context.MODE_PRIVATE);
+
+        String clientId = preferences.getString(STORAGE_KEY, null);
+        if (clientId == null) {
+            clientId = UUID.randomUUID().toString();
+
+            MobileCore.getLogger().info(MetricsService.TAG, "Generated a new client ID: " + clientId);
+
+            SharedPreferences.Editor editor = preferences.edit();
+            editor.putString(STORAGE_KEY, clientId);
+            editor.commit();
+        }
+
+        return clientId;
+    }
+
+    /**
+     * Get the user app version from the package manager
+     *
+     * @param context Android application context
+     * @return String app version name
+     */
+    private String getAppVersion(final Context context) throws JSONException {
+        try {
+            return context
+                .getPackageManager()
+                .getPackageInfo(context.getPackageName(), 0)
+                .versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            // Wrap in Initialization exception
+            throw new JSONException(e.getMessage());
+        }
+    }
+
+    @Override
+    public String namespace() {
+        return null;
+    }
+
+    @Override
+    public JSONObject metrics(final Context context) throws JSONException {
+        final JSONObject result = super.metrics(context);
+        result.put("clientId", getOrCreateClientId(context));
+        result.put("appId", context.getPackageName());
+        result.put("appVersion", getAppVersion(context));
+        result.put("sdkVersion", MobileCore.getSdkVersion());
+        result.put("platform", "android");
+        result.put("platformVersion", Build.VERSION.SDK_INT);
+        return result;
+    }
+}

--- a/metrics/src/main/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProvider.java
+++ b/metrics/src/main/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProvider.java
@@ -14,9 +14,6 @@ import org.json.JSONObject;
 import java.util.UUID;
 
 public class DefaultMetricsProvider extends MetricsProvider {
-    public final static String STORAGE_NAME = "org.aerogear.mobile.metrics";
-    public final static String STORAGE_KEY = "metrics-sdk-installation-id";
-
     /**
      * Get or create the client ID that identifies a device as long as the user doesn't
      * reinstall the app or delete the app storage. A random UUID is created and stored in the
@@ -29,16 +26,16 @@ public class DefaultMetricsProvider extends MetricsProvider {
      */
     protected String getOrCreateClientId(final Context context) {
         final SharedPreferences preferences = context
-            .getSharedPreferences(STORAGE_NAME, Context.MODE_PRIVATE);
+            .getSharedPreferences(MetricsService.STORAGE_NAME, Context.MODE_PRIVATE);
 
-        String clientId = preferences.getString(STORAGE_KEY, null);
+        String clientId = preferences.getString(MetricsService.STORAGE_KEY, null);
         if (clientId == null) {
             clientId = UUID.randomUUID().toString();
 
             MobileCore.getLogger().info(MetricsService.TAG, "Generated a new client ID: " + clientId);
 
             SharedPreferences.Editor editor = preferences.edit();
-            editor.putString(STORAGE_KEY, clientId);
+            editor.putString(MetricsService.STORAGE_KEY, clientId);
             editor.commit();
         }
 

--- a/metrics/src/test/java/org/aerogear/mobile/metrics/MetricsServiceTest.java
+++ b/metrics/src/test/java/org/aerogear/mobile/metrics/MetricsServiceTest.java
@@ -2,6 +2,7 @@ package org.aerogear.mobile.metrics;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
@@ -57,6 +58,8 @@ public class MetricsServiceTest {
         result.put("appId", MOCK_PKG);
         result.put("appVersion", MOCK_VSN);
         result.put("sdkVersion", MobileCore.getSdkVersion());
+        result.put("platform", "android");
+        result.put("platformVersion", Build.VERSION.SDK_INT);
         return result;
     }
 

--- a/metrics/src/test/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProviderTest.java
+++ b/metrics/src/test/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProviderTest.java
@@ -1,0 +1,7 @@
+package org.aerogear.mobile.metrics.providers;
+
+import static org.junit.Assert.*;
+
+public class DefaultMetricsProviderTest {
+
+}

--- a/metrics/src/test/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProviderTest.java
+++ b/metrics/src/test/java/org/aerogear/mobile/metrics/providers/DefaultMetricsProviderTest.java
@@ -1,7 +1,0 @@
-package org.aerogear.mobile.metrics.providers;
-
-import static org.junit.Assert.*;
-
-public class DefaultMetricsProviderTest {
-
-}


### PR DESCRIPTION
## Motivation

Changes for extensible metrics. Allow other SDK modules to add their metrics.

JIRA: https://issues.jboss.org/browse/AGDROID-730

## Description

Allow other SDK modules to add their metrics by implementing `MetricsProvider` and adding it to the MetricsRegistry. Initially i wanted to make it work automagically by using an AnnotationProcessor that collects marked classes and exposes them to the metrics service. But that turned out to not work very well.

