### PR TITLE
 🚀  allow build the auth module

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -6,13 +6,7 @@ android {
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
-
-        versionCode 1
-        versionName "1.0"
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        manifestPlaceholders = ['appAuthRedirectScheme': 'com.aerogear.android.auth']
     }
 
     buildTypes {
@@ -40,3 +34,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.robolectric:robolectric'
 }
+
+apply from: "../gradle-mvn-push.gradle"

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AeroGear Android SDK
+POM_ARTIFACT_ID=auth
+POM_PACKAGING=aar

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImpl.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImpl.java
@@ -72,8 +72,7 @@ public class OIDCAuthenticatorImpl extends AbstractAuthenticator {
      * Builds a new OIDCUserPrincipalImpl object after the user's credential has been authenticated
      *
      * @param authOptions the OIDC authentication options
-     * @return a new OIDCUserPrincipalImpl object with the user's identity that was decoded from the user's credential
-     * @throws AuthenticationException
+     * @param callback the callback will be invoked with a new OIDCUserPrincipalImpl object with the user's identity that was decoded from the user's credential
      */
     @Override
     public void authenticate(final AuthenticateOptions authOptions, final Callback<UserPrincipal> callback) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':core', ':keycloak-service-module', ':auth', ':metrics', ':example'
+include ':core', ':auth', ':metrics', ':example'


### PR DESCRIPTION
## Motivation

At the moment, `./gradlew install` doesn't build the auth module.

## Description

Update the build configuration of the auth module to make it buildable

## Progress

- [x] Update auth module build config


## Additional Notes

To test, run `./gradlew install`. It should finish successfully and the directory `~/.m2/repository/org/aerogear/auth` should exist.

ping @TommyJ1994 
