### PR TITLE
Flag required fields

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -41,7 +41,7 @@ public class MetricsService implements ServiceModule {
         if (metricsUrl == null) {
             publisher = new LoggerMetricsPublisher(MobileCore.getLogger());
         } else {
-            publisher = new NetworkMetricsPublisher(core.getHttpLayer().newRequest(), metricsUrl);
+            publisher = new NetworkMetricsPublisher(core.getContext(), core.getHttpLayer().newRequest(), metricsUrl);
         }
     }
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/metrics/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/metrics/DeviceMetrics.java
@@ -16,15 +16,11 @@ import java.util.UUID;
  */
 public class DeviceMetrics implements Metrics {
 
-    private final static String STORAGE_NAME = "org.aerogear.mobile.metrics";
-    private final static String STORAGE_KEY = "metrics-sdk-installation-id";
-
-    private final String clientId;
     private final String platform;
     private final String platformVersion;
 
     public DeviceMetrics(final Context context) {
-        this.clientId = getOrCreateClientId(context);
+
         this.platform = "android";
         this.platformVersion = String.valueOf(Build.VERSION.SDK_INT);
     }
@@ -37,37 +33,11 @@ public class DeviceMetrics implements Metrics {
     @Override
     public Map<String, String> data() {
         Map<String, String> data = new HashMap<>();
-        data.put("clientId", clientId);
         data.put("platform", platform);
         data.put("platformVersion", platformVersion);
         return data;
     }
 
-    /**
-     * Get or create the client ID that identifies a device as long as the user doesn't
-     * reinstall the app or delete the app storage. A random UUID is created and stored in the
-     * application shared preferences.
-     *
-     * @param context Application context
-     * @return Client ID
-     */
-    private String getOrCreateClientId(final Context context) {
-        final SharedPreferences preferences = context
-            .getSharedPreferences(STORAGE_NAME, Context.MODE_PRIVATE);
 
-        String clientId = preferences.getString(STORAGE_KEY, null);
-
-        if (clientId == null) {
-            clientId = UUID.randomUUID().toString();
-
-            MobileCore.getLogger().info("Generated a new client ID: " + clientId);
-
-            SharedPreferences.Editor editor = preferences.edit();
-            editor.putString(STORAGE_KEY, clientId);
-            editor.apply();
-        }
-
-        return clientId;
-    }
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -7,7 +7,7 @@ import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.core.metrics.MetricsPublisher;
-import org.aerogear.mobile.core.utils.AppIdGenerator;
+import org.aerogear.mobile.core.utils.ClientIdGenerator;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -39,7 +39,7 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
                 json.put(m.identifier(), new JSONObject(m.data()));
             }
             json.put("timestamp", System.currentTimeMillis());
-            json.put("clientId", AppIdGenerator.getOrCreateClientId(context));
+            json.put("clientId", ClientIdGenerator.getOrCreateClientId(context));
             httpRequest.post(url, json.toString().getBytes());
 
             MobileCore.getLogger().debug("Sending metrics");

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -32,14 +32,15 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
             for (final Metrics m : metrics) {
                 json.put(m.identifier(), new JSONObject(m.data()));
             }
-
+            json.put("timestamp","TODO");
+            json.put("appId","TODO");
             httpRequest.post(url, json.toString().getBytes());
 
             MobileCore.getLogger().debug("Sending metrics");
             HttpResponse httpResponse = httpRequest.execute();
             httpResponse.onComplete(() -> {
                 if (httpResponse.getStatus() == HTTP_OK) {
-                    MobileCore.getLogger().debug("Metrics sent");
+                    MobileCore.getLogger().debug("Metrics sent",json.toString());
                 } else {
                     MobileCore.getLogger().error(httpResponse.getRequestError().getMessage(),
                         httpResponse.getRequestError());

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -39,7 +39,7 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
                 json.put(m.identifier(), new JSONObject(m.data()));
             }
             json.put("timestamp", System.currentTimeMillis());
-            json.put("appId", AppIdGenerator.getOrCreateClientId(context));
+            json.put("clientId", AppIdGenerator.getOrCreateClientId(context));
             httpRequest.post(url, json.toString().getBytes());
 
             MobileCore.getLogger().debug("Sending metrics");

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -1,10 +1,13 @@
 package org.aerogear.mobile.core.metrics.publisher;
 
+import android.content.Context;
+
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.core.metrics.MetricsPublisher;
+import org.aerogear.mobile.core.utils.AppIdGenerator;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -15,10 +18,12 @@ import static java.net.HttpURLConnection.HTTP_OK;
  */
 public class NetworkMetricsPublisher implements MetricsPublisher {
 
+    private Context context;
     private HttpRequest httpRequest;
     private String url;
 
-    public NetworkMetricsPublisher(HttpRequest httpRequest, String url) {
+    public NetworkMetricsPublisher(Context context, HttpRequest httpRequest, String url) {
+        this.context = context;
         this.httpRequest = httpRequest;
         this.url = url;
     }
@@ -29,18 +34,19 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
         try {
 
             JSONObject json = new JSONObject();
+            // Can we build DTO here instead of operating on JSONObject?
             for (final Metrics m : metrics) {
                 json.put(m.identifier(), new JSONObject(m.data()));
             }
-            json.put("timestamp","TODO");
-            json.put("appId","TODO");
+            json.put("timestamp", System.currentTimeMillis());
+            json.put("appId", AppIdGenerator.getOrCreateClientId(context));
             httpRequest.post(url, json.toString().getBytes());
 
             MobileCore.getLogger().debug("Sending metrics");
             HttpResponse httpResponse = httpRequest.execute();
             httpResponse.onComplete(() -> {
                 if (httpResponse.getStatus() == HTTP_OK) {
-                    MobileCore.getLogger().debug("Metrics sent",json.toString());
+                    MobileCore.getLogger().debug("Metrics sent", json.toString());
                 } else {
                     MobileCore.getLogger().error(httpResponse.getRequestError().getMessage(),
                         httpResponse.getRequestError());

--- a/core/src/main/java/org/aerogear/mobile/core/utils/AppIdGenerator.java
+++ b/core/src/main/java/org/aerogear/mobile/core/utils/AppIdGenerator.java
@@ -1,0 +1,44 @@
+package org.aerogear.mobile.core.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.aerogear.mobile.core.MobileCore;
+
+import java.util.UUID;
+
+/**
+ * Helper for generating ID's
+ */
+public class AppIdGenerator {
+
+    private final static String STORAGE_NAME = "org.aerogear.mobile.metrics";
+    private final static String STORAGE_KEY = "metrics-sdk-installation-id";
+
+    /**
+     * Get or create the client ID that identifies a device as long as the user doesn't
+     * reinstall the app or delete the app storage. A random UUID is created and stored in the
+     * application shared preferences.
+     *
+     * @param context Application context
+     * @return Client ID
+     */
+    public static String getOrCreateClientId(final Context context) {
+        final SharedPreferences preferences = context
+            .getSharedPreferences(STORAGE_NAME, Context.MODE_PRIVATE);
+
+        String clientId = preferences.getString(STORAGE_KEY, null);
+
+        if (clientId == null) {
+            clientId = UUID.randomUUID().toString();
+
+            MobileCore.getLogger().info("Generated a new client ID: " + clientId);
+
+            SharedPreferences.Editor editor = preferences.edit();
+            editor.putString(STORAGE_KEY, clientId);
+            editor.apply();
+        }
+
+        return clientId;
+    }
+}

--- a/core/src/main/java/org/aerogear/mobile/core/utils/ClientIdGenerator.java
+++ b/core/src/main/java/org/aerogear/mobile/core/utils/ClientIdGenerator.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 /**
  * Helper for generating ID's
  */
-public class AppIdGenerator {
+public class ClientIdGenerator {
 
     private final static String STORAGE_NAME = "org.aerogear.mobile.metrics";
     private final static String STORAGE_KEY = "metrics-sdk-installation-id";

--- a/core/src/test/java/org/aerogear/mobile/core/metrics/metrics/DeviceMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/metrics/metrics/DeviceMetricsTest.java
@@ -33,7 +33,6 @@ public class DeviceMetricsTest {
         DeviceMetrics deviceMetrics = new DeviceMetrics(context);
         Map<String, String> result = deviceMetrics.data();
 
-        assertNotNull(result.get("clientId"));
         assertNotNull(result.get("platform"));
         assertNotNull(result.get("platformVersion"));
     }


### PR DESCRIPTION
## Motivation

Allow to have app id on the top level so we will be able to retrieve metrics for specific application (if needed)
Add timestamp as in proposal to track when metrics were collected and send 

WIP idea for additional requirements.

## Tech notes

Two ways of doing this:
1. Change way we store metrics from `Metrics[]` to separate class containing it as field. 
1. Include that in publisher (probably worse) - implemented in this PR

## Tasks

- [x] Implementation
- [x] Adjust unit tests



