### PR TITLE
Avoid double metrics.metrics package name

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -3,8 +3,8 @@ package org.aerogear.mobile.core.metrics;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.ServiceModule;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
-import org.aerogear.mobile.core.metrics.metrics.AppMetrics;
-import org.aerogear.mobile.core.metrics.metrics.DeviceMetrics;
+import org.aerogear.mobile.core.metrics.impl.AppMetrics;
+import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
 import org.aerogear.mobile.core.metrics.publisher.LoggerMetricsPublisher;
 import org.aerogear.mobile.core.metrics.publisher.NetworkMetricsPublisher;
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.metrics.metrics;
+package org.aerogear.mobile.core.metrics.impl;
 
 import android.content.Context;
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
@@ -1,15 +1,12 @@
-package org.aerogear.mobile.core.metrics.metrics;
+package org.aerogear.mobile.core.metrics.impl;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Build;
 
-import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.Metrics;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Collects device metrics

--- a/core/src/test/java/org/aerogear/mobile/core/metrics/impl/AppMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/metrics/impl/AppMetricsTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.metrics.metrics;
+package org.aerogear.mobile.core.metrics.impl;
 
 import android.app.Application;
 import android.support.test.filters.SmallTest;

--- a/core/src/test/java/org/aerogear/mobile/core/metrics/impl/DeviceMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/metrics/impl/DeviceMetricsTest.java
@@ -1,9 +1,8 @@
-package org.aerogear.mobile.core.metrics.metrics;
+package org.aerogear.mobile.core.metrics.impl;
 
 import android.app.Application;
 import android.support.test.filters.SmallTest;
 
-import org.aerogear.mobile.core.metrics.metrics.DeviceMetrics;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;


### PR DESCRIPTION
## Motivation

package `metrics.metrics` looks more than just bizarre. Moving the two concrete 'implementations' for our Metrics to a slightly better named package (`impl`)


## Description

Fixing odd package structure

## Progress

- [x] Done Task

## Additional Notes

