### PR TITLE
Add link to Core/Auth Getting Started Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 
 AeroGear Services SDK consist of set of separate SDKs
 
-- [Core](./docs/core/README.adoc): Common base for all SDKs
-- [Auth](./docs/auth/README.adoc):  Mobile authentication SDK
+- [Core](./docs/getting-started/core.adoc): Common base for all SDKs
+- [Auth](./docs/getting-started/auth.adoc):  Mobile authentication SDK
 
 ## Contributing
 


### PR DESCRIPTION
## Motivation
Some links on the main README are 404'ing.

## Description
Update links to the getting started guide for Core and Auth.

## Progress

- [x] Fix Links
