### PR TITLE
Add Backchannel Logout Note

### DIFF
--- a/docs/getting-started/auth.adoc
+++ b/docs/getting-started/auth.adoc
@@ -200,3 +200,7 @@ UserPrincipal currentUser = authService.currentUser();
 
 authService.logout(currentUser);
 ----
+
+*Note:* To perform backchannel or federated logouts, you must enable the Backchannel Logout option for the federated identity provider. More information is available in the Keycloak documentation under  http://www.keycloak.org/docs/latest/server_admin/index.html#openid-connect-v1-0-identity-providers[OIDC Identity Providers].
+
+


### PR DESCRIPTION
## Motivation
By default, federated won't work unless the user enables backchannel logouts for their federated IDP.

## Description
Add a note for a how a user should enable this, otherwise there mobile app will experience unexpected behavior when trying to logout.

## Progress

- [x] Add note