### PR TITLE
non null for passed in arguments should throw IllegalArgumentException

### DIFF
--- a/auth/src/test/java/org/aerogear/mobile/auth/AuthServiceTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/AuthServiceTest.java
@@ -77,9 +77,9 @@ public class AuthServiceTest {
 
         try {
             authService.login(null, null);
-        } catch (NullPointerException npe) {
+        } catch (IllegalArgumentException iae) {
             // The service is ready: it must give an error because no callback has been provided
-            Assert.assertEquals("Parameter 'callback' can't be null", npe.getMessage());
+            Assert.assertEquals("Parameter 'callback' can't be null", iae.getMessage());
         }
     }
 }

--- a/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticateOptionsTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticateOptionsTest.java
@@ -21,7 +21,7 @@ public class OIDCAuthenticateOptionsTest {
         MockitoAnnotations.initMocks(this);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testParameterValidation() {
         new OIDCAuthenticateOptions(null, 5);
     }

--- a/auth/src/test/java/org/aerogear/mobile/auth/utils/UserIdentityParserTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/utils/UserIdentityParserTest.java
@@ -46,7 +46,7 @@ public class UserIdentityParserTest {
         parser = new UserIdentityParser(credential, keycloakConfiguration);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testUserIdentityParser_NullServiceConfig() throws JSONException, AuthenticationException {
         parser = new UserIdentityParser(credential, null);
     }

--- a/core/src/main/java/org/aerogear/mobile/core/utils/SanityCheck.java
+++ b/core/src/main/java/org/aerogear/mobile/core/utils/SanityCheck.java
@@ -38,7 +38,7 @@ public final class SanityCheck {
      */
     public static <T> T nonNull(final T value, final String customMessage, final Object ... params) {
         if (value == null) {
-            throw new NullPointerException(String.format(customMessage, params));
+            throw new IllegalArgumentException(String.format(customMessage, params));
         }
         return value;
     }

--- a/core/src/test/java/org/aerogear/mobile/core/utils/SanityCheckTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/utils/SanityCheckTest.java
@@ -16,8 +16,8 @@ public class SanityCheckTest {
         try {
             SanityCheck.nonNull(null, "test-param");
             Assert.fail("null value has not been detected");
-        } catch(NullPointerException npe) {
-            Assert.assertEquals("Parameter 'test-param' can't be null", npe.getMessage());
+        } catch(IllegalArgumentException iae) {
+            Assert.assertEquals("Parameter 'test-param' can't be null", iae.getMessage());
         }
     }
 
@@ -26,8 +26,8 @@ public class SanityCheckTest {
         try {
             SanityCheck.nonNull(null, "Test error message for %s param with custom %s string", "test-param", "custom-string");
             Assert.fail("null value has not been detected");
-        } catch(NullPointerException npe) {
-            Assert.assertEquals("Test error message for test-param param with custom custom-string string", npe.getMessage());
+        } catch(IllegalArgumentException iae) {
+            Assert.assertEquals("Test error message for test-param param with custom custom-string string", iae.getMessage());
         }
     }
 


### PR DESCRIPTION
## Motivation

If a null object is passed in, as an _argument_, and `IllegalArgumentException` needs to be thrown. NPE is only good when you invoke a null objects. But for checks on passed in objects, it's `IllegalArgumentException`

see: https://stackoverflow.com/questions/3881/illegalargumentexception-or-nullpointerexception-for-a-null-parameter

## Description

## Progress

- [x] Done Task
