### PR TITLE
Some fixes on OIDCCredential clazz

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/credentials/OIDCCredentials.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/credentials/OIDCCredentials.java
@@ -26,8 +26,6 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonEmpty;
 public class OIDCCredentials {
 
     private static final String TAG = "OIDCCredentials";
-    private static final String beginPublicKey = "-----BEGIN PUBLIC KEY-----";
-    private static final String endPublicKey = "-----END PUBLIC KEY-----";
 
     private final AuthState authState;
 
@@ -172,12 +170,13 @@ public class OIDCCredentials {
     }
 
     /**
-     * Renew the token
+     * Renew the token.
+     *
      * @return
-     * @throws IllegalStateException
+     * @throws UnsupportedOperationException
      */
     public boolean renew() throws AuthenticationException {
-        throw new IllegalStateException("Not yet implemented");
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override

--- a/auth/src/test/java/org/aerogear/mobile/auth/credentials/OIDCCredentialsTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/credentials/OIDCCredentialsTest.java
@@ -4,6 +4,7 @@ import junit.framework.Assert;
 
 import net.openid.appauth.AuthState;
 
+import org.aerogear.mobile.auth.AuthenticationException;
 import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.JsonWebKeySet;
@@ -71,7 +72,13 @@ public class OIDCCredentialsTest {
         assertEquals(serializedCredential.get("authState"), CREDENTIAL_AUTH_STATE);
     }
 
-    @Test
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRenew() throws AuthenticationException {
+        OIDCCredentials testCredential = new OIDCCredentials(CREDENTIAL_AUTH_STATE);
+        testCredential.renew();
+    }
+
+        @Test
     public void testDeserialize() throws JSONException {
         OIDCCredentials testCredential = new OIDCCredentials(CREDENTIAL_AUTH_STATE);
         String serialized = testCredential.serialize();


### PR DESCRIPTION
## Motivation

throwing `UnsupportedOperationException` in `renew` and adding a test


## Progress

- [x] Done Task

## Additional Notes
