### PR TITLE
Added back the 'addCheck' methods/Changed return value from array to Map

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
@@ -8,16 +8,17 @@ import android.support.annotation.Nullable;
 import org.aerogear.mobile.core.metrics.MetricsService;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * Base class for security check executors.
  */
-abstract class AbstractSecurityCheckExecutor {
+abstract class AbstractSecurityCheckExecutor<T extends AbstractSecurityCheckExecutor> {
 
     /**
      * Collection of checks to be executed.
      */
-    private final Collection<SecurityCheck> checks;
+    private final Collection<SecurityCheck> checks = new HashSet<>();
 
     /**
      * Context.
@@ -41,7 +42,7 @@ abstract class AbstractSecurityCheckExecutor {
                                          @Nullable final MetricsService metricService) {
         this.context = context;
         this.metricsService = metricService;
-        this.checks = checks;
+        this.checks.addAll(checks);
     }
 
     /**
@@ -58,5 +59,25 @@ abstract class AbstractSecurityCheckExecutor {
 
     protected MetricsService getMetricsService() {
         return metricsService;
+    }
+
+    /**
+     * Adds a new check to be executed
+     * @param check the new check to be executed
+     * @return this, so that adding checks can be chained
+     */
+    public T addCheck(SecurityCheck check) {
+        this.getChecks().add(check);
+        return (T) this;
+    }
+
+    /**
+     * Adds a new check to be executed
+     * @param checkType the type of the new check to be executed
+     * @return this, so that adding checks can be chained
+     */
+    public T addCheck(SecurityCheckType checkType) {
+        this.getChecks().add(checkType.getSecurityCheck());
+        return (T) this;
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Future;
  * Executor used to asynchronously execute checks.
  * Checks are executed by using {@link AppExecutors#singleThreadService()} if no custom executor is configured.
  */
-public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor {
+public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<AsyncSecurityCheckExecutor> {
 
     private final static String TAG = "AsyncSecurityCheckExecutor";
 

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheck.java
@@ -16,4 +16,10 @@ public interface SecurityCheck {
      * @return {@link SecurityCheckResult Result} of the test
      */
     SecurityCheckResult test(Context context);
+
+    /**
+     * Gets the name of the check. It must be a unique string.
+     * @return
+     */
+    public String getName();
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutor.java
@@ -7,10 +7,8 @@ import android.support.annotation.Nullable;
 
 import org.aerogear.mobile.core.metrics.MetricsService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * Entry point for the SecurityCheckExecutor.
@@ -33,7 +31,7 @@ public class SecurityCheckExecutor {
          */
         static abstract class AbstractBuilder<T, K> {
             private final Context ctx;
-            private final List<SecurityCheck> checks = new ArrayList<>();
+            private final Collection<SecurityCheck> checks = new HashSet<>();
             private MetricsService metricsService;
 
             public AbstractBuilder(@NonNull final Context ctx) {
@@ -80,7 +78,7 @@ public class SecurityCheckExecutor {
                 return metricsService;
             }
 
-            protected List<SecurityCheck> getChecks() {
+            protected Collection<SecurityCheck> getChecks() {
                 return checks;
             }
 

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckType.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckType.java
@@ -25,4 +25,13 @@ public enum SecurityCheckType {
     public SecurityCheck getSecurityCheck() {
         return check;
     }
+
+    /**
+     * Returns the name of this security check.
+     * The value is the same as {@link SecurityCheck#getName()}
+     * @return
+     */
+    public String getName() {
+        return getSecurityCheck().getName();
+    }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -48,38 +48,27 @@ public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<Syn
      * @return a {@link Map} containing the results of all the executed checks
      */
     public Map<String, SecurityCheckResult> execute() {
-        final Map<String, SecurityCheckResult> results = getTestResults();
-        if (getMetricsService() != null) {
-            publishResultMetrics(results.values());
+        final Map<String, SecurityCheckResult> results = new HashMap<>();
+
+        for (SecurityCheck check : getChecks()) {
+            SecurityCheckResult result = check.test(getContext());
+            results.put(check.getName(), result);
+            publishResultMetrics(result);
         }
-        return getTestResults();
+
+        return results;
     }
 
     /**
      * Publish each {@link SecurityCheckResult result} provided as an {@link SecurityCheckResultMetric}.
      *
-     * @param results Collection of results
+     * @param result result to be published
      */
-    private void publishResultMetrics(@NonNull final Collection <SecurityCheckResult> results) {
-        for(SecurityCheckResult result : results) {
-            this.getMetricsService().publish(new SecurityCheckResultMetric(result));
+    private void publishResultMetrics(@NonNull SecurityCheckResult result) {
+        MetricsService metricsService = getMetricsService();
+
+        if (metricsService != null) {
+            metricsService.publish(new SecurityCheckResultMetric(result));
         }
-    }
-
-    /**
-     * Returns a {@link Map} containing the results of each executed test.
-     * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
-     * the result of the check.
-     *
-     * @return a {@link Map} containing the results of all the executed checks
-     */
-    private Map<String, SecurityCheckResult> getTestResults() {
-
-        final Map<String, SecurityCheckResult> results = new HashMap<>();
-
-        for (SecurityCheck check : getChecks()) {
-            results.put(check.getName(), check.test(getContext()));
-        }
-        return results;
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -11,7 +11,9 @@ import org.aerogear.mobile.security.SecurityCheckResult;
 import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 /**
  * Synchronously executes provided {@link SecurityCheck}s.
@@ -39,12 +41,16 @@ public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<Syn
      * Executes the provided checks and returns the results.
      * Blocks until all checks are executed.
      *
-     * @return the results of the executed checks
+     * Returns a {@link Map} containing the results of each executed test.
+     * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
+     * the result of the check.
+     *
+     * @return a {@link Map} containing the results of all the executed checks
      */
-    public SecurityCheckResult[] execute() {
-        SecurityCheckResult[] results = getTestResults();
+    public Map<String, SecurityCheckResult> execute() {
+        final Map<String, SecurityCheckResult> results = getTestResults();
         if (getMetricsService() != null) {
-            publishResultMetrics(results);
+            publishResultMetrics(results.values());
         }
         return getTestResults();
     }
@@ -52,27 +58,27 @@ public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<Syn
     /**
      * Publish each {@link SecurityCheckResult result} provided as an {@link SecurityCheckResultMetric}.
      *
-     * @param results Array of results
+     * @param results Collection of results
      */
-    private void publishResultMetrics(final SecurityCheckResult[] results) {
+    private void publishResultMetrics(@NonNull final Collection <SecurityCheckResult> results) {
         for(SecurityCheckResult result : results) {
             this.getMetricsService().publish(new SecurityCheckResultMetric(result));
         }
     }
 
     /**
-     * Return the {@link SecurityCheckResult results} for each of the tests added.
+     * Returns a {@link Map} containing the results of each executed test.
+     * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
+     * the result of the check.
      *
-     * @return Array of results.
+     * @return a {@link Map} containing the results of all the executed checks
      */
-    private SecurityCheckResult[] getTestResults() {
+    private Map<String, SecurityCheckResult> getTestResults() {
 
-        Collection<SecurityCheck> checks = getChecks();
+        final Map<String, SecurityCheckResult> results = new HashMap<>();
 
-        SecurityCheckResult[] results = new SecurityCheckResult[checks.size()];
-        int i = 0;
-        for (SecurityCheck check : checks) {
-            results[i++] = check.test(getContext());
+        for (SecurityCheck check : getChecks()) {
+            results.put(check.getName(), check.test(getContext()));
         }
         return results;
     }

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 /**
  * Synchronously executes provided {@link SecurityCheck}s.
  */
-public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor {
+public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<SyncSecurityCheckExecutor> {
 
     public static class Builder extends SecurityCheckExecutor.Builder.AbstractBuilder<Builder, SyncSecurityCheckExecutor> {
         Builder(final Context ctx) {

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
@@ -25,4 +25,9 @@ public class RootedCheck implements SecurityCheck {
         final RootBeer rootBeer = new RootBeer(context);
         return new SecurityCheckResultImpl(NAME, rootBeer.isRooted());
     }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
 }

--- a/auth/src/test/java/org/aerogear/mobile/security/utils/MockSecurityCheck.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/utils/MockSecurityCheck.java
@@ -7,8 +7,16 @@ import org.aerogear.mobile.security.SecurityCheckResult;
 import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
 
 public class MockSecurityCheck implements SecurityCheck {
+
+    private static final String NAME = MockSecurityCheck.class.getName();
+
     @Override
     public SecurityCheckResult test(Context context) {
         return new SecurityCheckResultImpl("mockTest", true);
+    }
+
+    @Override
+    public String getName() {
+        return null;
     }
 }


### PR DESCRIPTION
## Motivation

Added back the 'addCheck' method that was erroneously removed
Changed the return value of the check executors: now a Map is returned (key: check name, value check result).

## Description

Re-added the addCheckMethods

## Progress
- [x] restore the addCheck method
- [x] change the return value of the executors to Map
- [x] update javadocs
- [x] update unit tests
