### PR TITLE
Circleci generate maven artifacts and test javadocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-26-alpha
+      - image: circleci/android:api-27-alpha
     environment:
       JVM_OPTS: -Xmx3200m
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,6 @@ jobs:
       - run:
           name: Run Tests
           command: ./gradlew lint testDebug
+      - run:
+          name: Generate Maven Artifacts
+          command: ./gradlew install

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -62,7 +62,7 @@ public class SecurityService implements ServiceModule{
      *
      * @param securityCheckType The type of check to execute
      * @return {@link SecurityCheckResult}
-     * @throws IllegalArgumentException if {@param securityCheckType} is null
+     * @throws IllegalArgumentException if securityCheckType is null
      */
     public SecurityCheckResult check(@NonNull final SecurityCheckType securityCheckType) {
         return check(nonNull(securityCheckType, "securityCheckType").getSecurityCheck());
@@ -73,7 +73,7 @@ public class SecurityService implements ServiceModule{
      *
      * @param securityCheck The check to execute
      * @return {@link SecurityCheckResult}
-     * @throws IllegalArgumentException if {@param securityCheck} is null
+     * @throws IllegalArgumentException if securityCheck is null
      */
     public SecurityCheckResult check(@NonNull final SecurityCheck securityCheck) {
         return nonNull(securityCheck, "securityCheck").test(core.getContext());
@@ -84,6 +84,7 @@ public class SecurityService implements ServiceModule{
      * publish a {@link SecurityCheckResultMetric} based on the result.
      *
      * @param securityCheckType The type of check to execute
+     * @param metricsService The metrics service to use
      * @return {@link SecurityCheckResult}
      */
     public SecurityCheckResult checkAndSendMetric(final SecurityCheckType securityCheckType, final MetricsService metricsService) {
@@ -94,6 +95,7 @@ public class SecurityService implements ServiceModule{
      * Perform a single {@link SecurityCheck} , and return a {@link SecurityCheckResult}.
      *
      * @param securityCheck The check to execute
+     * @param metricsService The metrics service to use
      * @return {@link SecurityCheckResult}
      */
     public SecurityCheckResult checkAndSendMetric(final SecurityCheck securityCheck, final MetricsService metricsService) {

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/AbstractSecurityCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/AbstractSecurityCheck.java
@@ -18,7 +18,7 @@ public abstract class AbstractSecurityCheck implements SecurityCheck {
      *
      * @param context Context to be used by the check
      * @return {@link SecurityCheckResult} embedding the result of {@link #execute(Context)}
-     * @throws IllegalArgumentException if {@param context} is null
+     * @throws IllegalArgumentException if context is null
      */
     @Override
     public final SecurityCheckResult test(@NonNull final Context context) {

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
@@ -30,6 +30,7 @@ public class RootedCheck extends AbstractSecurityCheck {
     /**
      * This method allows us to perform unit testing on the Rooted Check
      * @param context Context to be used
+     * @return a RootBeer instance
      */
     protected RootBeer getRootBeer(final Context context) {
         return new RootBeer(context);

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.internal.logging.events.OutputEvent
+import org.gradle.internal.logging.events.OutputEventListener
+import org.gradle.internal.logging.LoggingOutputInternal
 
 apply plugin: 'maven'
 apply plugin: 'signing'
@@ -126,5 +129,23 @@ afterEvaluate { project ->
 
         jarSourceTask.dependsOn variant.javaCompile
         artifacts.add('archives', jarSourceTask)
+    }
+}
+
+tasks.withType(Javadoc) {
+    def warnings = []
+    doFirst {
+        gradle.services.get(LoggingOutputInternal).addOutputEventListener(new OutputEventListener() {
+            void onOutput(OutputEvent event) {
+                if (event.toString() =~ "warning") {
+                    warnings << "Javadoc warning: ${event.toString()}"
+                }
+            }
+        })
+    }
+    doLast {
+        if (warnings.size()> 0) {
+            throw new GradleException(warnings.join('\n'));
+        }
     }
 }


### PR DESCRIPTION
## Motivation

CircleCi didn't fail if there were javadoc warnings.  This was causing issues because some versions of javadoc are more strict and treat warnings as errors.
JIRA: https://issues.jboss.org/browse/AGDROID-768

## Progress

- [x] Fix existing javadoc warnings
- [x] Add checks to Circle CI
- [x] Updated Android used by CircleCI

## Additional Notes

You can follow my tests here : https://circleci.com/gh/secondsun/aerogear-android-sdk/tree/circleci_generate_maven_artifacts

One of things you might want to exercise when you test is adding javadoc errors locally and making sure that `./gradlew install` fails your build.  Bonus points if you test your own circleCi
