### PR TITLE
Example app crashing fix.

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -58,18 +58,18 @@ public class SecurityService implements ServiceModule{
     }
 
     /**
-     * Perform a single {@link SecurityCheckType} and get the {@link SecurityCheckResult result} for it.
+     * Used with enumeration to perform a single {@link SecurityCheckType} and get the {@link SecurityCheckResult result} for it.
      *
      * @param securityCheckType The type of check to execute
      * @return {@link SecurityCheckResult}
      * @throws IllegalArgumentException if {@param securityCheckType} is null
      */
     public SecurityCheckResult check(@NonNull final SecurityCheckType securityCheckType) {
-        return nonNull(securityCheckType, "securityCheckType").getSecurityCheck().test(core.getContext());
+        return check(nonNull(securityCheckType, "securityCheckType").getSecurityCheck());
     }
 
     /**
-     * Perform a single {@link SecurityCheck} and get the {@link SecurityCheckResult result} for it.
+     * Used with a custom check to perform a single {@link SecurityCheck} and get the {@link SecurityCheckResult result} for it.
      *
      * @param securityCheck The check to execute
      * @return {@link SecurityCheckResult}

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -65,7 +65,7 @@ public class SecurityService implements ServiceModule{
      * @throws IllegalArgumentException if {@param securityCheckType} is null
      */
     public SecurityCheckResult check(@NonNull final SecurityCheckType securityCheckType) {
-        return nonNull(securityCheckType, "securityCheckType").getSecurityCheck().test(core.getContext()git );
+        return nonNull(securityCheckType, "securityCheckType").getSecurityCheck().test(core.getContext());
     }
 
     /**

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -65,7 +65,7 @@ public class SecurityService implements ServiceModule{
      * @throws IllegalArgumentException if {@param securityCheckType} is null
      */
     public SecurityCheckResult check(@NonNull final SecurityCheckType securityCheckType) {
-        return check(nonNull(securityCheckType, "securityCheckType").getSecurityCheck());
+        return nonNull(securityCheckType, "securityCheckType").getSecurityCheck().test(core.getContext()git );
     }
 
     /**

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -65,7 +65,7 @@ public class SecurityService implements ServiceModule{
      * @throws IllegalArgumentException if {@param securityCheckType} is null
      */
     public SecurityCheckResult check(@NonNull final SecurityCheckType securityCheckType) {
-        return (SecurityCheckResult) nonNull(securityCheckType, "securityCheckType").getSecurityCheck();
+        return check(nonNull(securityCheckType, "securityCheckType").getSecurityCheck());
     }
 
     /**


### PR DESCRIPTION
## Motivation

The example app was crashing when the self defense checks where loaded.

## Description

The crash was caused by a cast in the SecurityService class. We where trying to cast SecurityCheckResult to a SecurityCheck, by removing the cast and returning a SecurityCheckResult we stop the example app from crashing 

