### PR TITLE
Added base class to remove duplicate code

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/security/checks/AbstractSecurityCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/AbstractSecurityCheck.java
@@ -1,0 +1,34 @@
+package org.aerogear.mobile.security.checks;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import org.aerogear.mobile.security.SecurityCheck;
+import org.aerogear.mobile.security.SecurityCheckResult;
+import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
+
+import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
+
+/**
+ * Base class for security checks.
+ */
+public abstract class AbstractSecurityCheck implements SecurityCheck {
+    /**
+     * Checks that the context is not null and delegates the check execution to the {@link #execute(Context)} method.
+     *
+     * @param context Context to be used by the check
+     * @return {@link SecurityCheckResult} embedding the result of {@link #execute(Context)}
+     * @throws IllegalArgumentException if {@param context} is null
+     */
+    @Override
+    public final SecurityCheckResult test(@NonNull final Context context) {
+        return new SecurityCheckResultImpl(this, execute(nonNull(context, "context")));
+    }
+
+    /**
+     * Executes the check. Context is guaranteed to be non null.
+     * @param context context to be used to perform the check
+     * @return <code>true</code> if the check has passed, <code>false</code> otherwise
+     */
+    protected abstract boolean execute(@NonNull final Context context);
+}

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/DebuggerCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/DebuggerCheck.java
@@ -12,7 +12,8 @@ import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
 /**
  * A check for whether a debugger is attached to the current application.
  */
-public class DebuggerCheck implements SecurityCheck {
+public class DebuggerCheck extends AbstractSecurityCheck {
+
     /**
      * Check whether a debugger is attached to the current application.
      *
@@ -20,7 +21,7 @@ public class DebuggerCheck implements SecurityCheck {
      * @return <code>true</code> if device is in debug mode
      */
     @Override
-    public SecurityCheckResult test(@NonNull final Context context) {
-        return new SecurityCheckResultImpl(this, Debug.isDebuggerConnected());
+    protected boolean execute(@NonNull Context context) {
+        return Debug.isDebuggerConnected();
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/DeveloperModeCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/DeveloperModeCheck.java
@@ -14,17 +14,17 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 /**
  * Security check that detects if developer mode is enabled in the device.
  */
-public class DeveloperModeCheck implements SecurityCheck {
+public class DeveloperModeCheck extends AbstractSecurityCheck {
+
     /**
      * Check if developer mode has been enabled in the device.
      *
      * @param context Context to be used by the check.
      * @return <code>true</code> if the developer options have been enabled on the device.
-     * @throws IllegalArgumentException if {@param context} is null
      */
     @Override
-    public SecurityCheckResult test(@NonNull final Context context) {
-        int devOptions = Settings.Secure.getInt(nonNull(context, "context").getContentResolver(), Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0);
-        return new SecurityCheckResultImpl(this, devOptions > 0);
+    protected boolean execute(@NonNull Context context) {
+        int devOptions = Settings.Secure.getInt(context.getContentResolver(), Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0);
+        return devOptions > 0;
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/EmulatorCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/EmulatorCheck.java
@@ -11,17 +11,7 @@ import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
 /**
  * A check for whether the device the application is running on an emulator
  */
-public class EmulatorCheck implements SecurityCheck {
-    /**
-     * Check whether the device is an emulator.
-     *
-     * @param context Context to be used by the check.
-     * @return <code>true</code> if the device is an emulator.
-     */
-    @Override
-    public SecurityCheckResult test(@NonNull final Context context) {
-        return new SecurityCheckResultImpl(this, isEmulator());
-    }
+public class EmulatorCheck extends AbstractSecurityCheck {
 
     /**
      * Checks if device is an emulator by looking at the following:
@@ -33,7 +23,8 @@ public class EmulatorCheck implements SecurityCheck {
      *
      * @return <code>true</code> if device is an emulator
      */
-    private boolean isEmulator(){
+    @Override
+    protected boolean execute(@NonNull Context context) {
         return Build.FINGERPRINT.startsWith("generic")
             || Build.FINGERPRINT.startsWith("unknown")
             || Build.MODEL.contains("google_sdk")
@@ -44,4 +35,5 @@ public class EmulatorCheck implements SecurityCheck {
             || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
             || "google_sdk".equals(Build.PRODUCT);
     }
+
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
@@ -14,17 +14,17 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 /**
  * A check for whether the device the application is running on is rooted.
  */
-public class RootedCheck implements SecurityCheck {
+public class RootedCheck extends AbstractSecurityCheck {
+
     /**
      * Check whether the device is rooted or not.
      *
      * @param context Context to be used by the check.
      * @return <code>true</code> if the device is rooted.
-     * @throws IllegalArgumentException if {@param context} is null
      */
     @Override
-    public SecurityCheckResult test(@NonNull final Context context) {
-        return new SecurityCheckResultImpl(this, getRootBeer(nonNull(context, "context")).isRooted());
+    protected boolean execute(@NonNull Context context) {
+        return getRootBeer(context).isRooted();
     }
 
     /**
@@ -34,5 +34,4 @@ public class RootedCheck implements SecurityCheck {
     protected RootBeer getRootBeer(final Context context) {
         return new RootBeer(context);
    }
-
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/ScreenLockCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/ScreenLockCheck.java
@@ -15,21 +15,22 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 /**
  * A check for whether the device the application is running on has a screen lock.
  */
-public class ScreenLockCheck implements SecurityCheck {
+public class ScreenLockCheck extends AbstractSecurityCheck {
+
     /**
      * Check whether the device has a screen lock enabled (PIN, Password, etc).
      *
      * @param context Context to be used by the check.
      * @return <code>true</code> if the device has a screen lock enabled.
-     * @throws IllegalArgumentException if {@param context} is null
      */
     @Override
-    public SecurityCheckResult test(@NonNull final Context context){
-        final KeyguardManager keyguardManager = (KeyguardManager) nonNull(context, "context").getSystemService(Context.KEYGUARD_SERVICE);
+    protected boolean execute(@NonNull Context context) {
+        final KeyguardManager keyguardManager = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+
         // KeyguardManager#isDeviceSecure() was added in Android M.
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
-            return new SecurityCheckResultImpl(this, keyguardManager.isDeviceSecure());
+            return keyguardManager.isDeviceSecure();
         }
-        return new SecurityCheckResultImpl(this, keyguardManager.isKeyguardSecure());
+        return keyguardManager.isKeyguardSecure();
     }
 }


### PR DESCRIPTION
## Motivation

Each security check marks the `context` as nonnull and sanity checks are duplicated in every security check implementation.
Moreover, each security check implementation is polluted with code to build the `SecurityCheckResult` object just to return a boolean.

## Description

Created a base class that delegates to subclasses the implementation of the check by simply implementing the `execute` method and just returning a `boolean`.

The `execute` method is guaranteed to receive a nonnull context, so no check need to be performed there.

The `SecurityResult` object is built in the base class automatically, so no need to worry about that in the real check implementation

## Progress

- [x] Add AbstractSecurityCheck class
- [x] Ensure tests still works 
