### PR TITLE
AEROGEAR-2208 Add allow backup flag check

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckType.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckType.java
@@ -1,6 +1,7 @@
 package org.aerogear.mobile.security;
 
 
+import org.aerogear.mobile.security.checks.AllowBackupFlagCheck;
 import org.aerogear.mobile.security.checks.DeveloperModeCheck;
 import org.aerogear.mobile.security.checks.DebuggerCheck;
 import org.aerogear.mobile.security.checks.EmulatorCheck;
@@ -36,7 +37,12 @@ public enum SecurityCheckType {
      *  Detect whether a screen lock is enabled (PIN, Password etc).
      *  See {@link ScreenLockCheck}
      */
-    SCREEN_LOCK_ENABLED(new ScreenLockCheck());
+    SCREEN_LOCK_ENABLED(new ScreenLockCheck()),
+    /**
+     * Detect whether the allowBackup flag is enabled for the application.
+     * See {@link AllowBackupFlagCheck}
+     */
+    ALLOW_BACKUP_ENABLED(new AllowBackupFlagCheck());
 
     private SecurityCheck check;
 

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/AllowBackupFlagCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/AllowBackupFlagCheck.java
@@ -1,0 +1,32 @@
+package org.aerogear.mobile.security.checks;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.support.annotation.NonNull;
+
+/**
+ * Check to determine whether the allowBackup flag is enabled for the application.
+ * The allowBackup flag determines whether to allow the application to participate in the backup
+ * and restore infrastructure.
+ */
+public class AllowBackupFlagCheck extends AbstractSecurityCheck{
+    /**
+     * Check whether the allowBackup flag is enabled.
+     *
+     * @param context Context to be used by the check.
+     * @return true if allowBackup is enabled.
+     * @throws IllegalStateException Will be thrown if package information can not be found.
+     */
+    @Override
+    public boolean execute(@NonNull final Context context) {
+        PackageInfo packageInfo;
+        try {
+            packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+        } catch (NameNotFoundException e) {
+            throw new IllegalStateException("Could not retrieve package information from provided context", e);
+        }
+        return (packageInfo.applicationInfo.flags & ApplicationInfo.FLAG_ALLOW_BACKUP) != 0;
+    }
+}

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/DebuggerCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/DebuggerCheck.java
@@ -4,11 +4,6 @@ import android.content.Context;
 import android.os.Debug;
 import android.support.annotation.NonNull;
 
-import org.aerogear.mobile.security.SecurityCheck;
-import org.aerogear.mobile.security.SecurityCheckResult;
-import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
-
-
 /**
  * A check for whether a debugger is attached to the current application.
  */

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/DeveloperModeCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/DeveloperModeCheck.java
@@ -4,12 +4,6 @@ import android.content.Context;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
 
-import org.aerogear.mobile.security.SecurityCheck;
-import org.aerogear.mobile.security.SecurityCheckResult;
-import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
-
-import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
-
 
 /**
  * Security check that detects if developer mode is enabled in the device.

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/EmulatorCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/EmulatorCheck.java
@@ -4,10 +4,6 @@ import android.content.Context;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
-import org.aerogear.mobile.security.SecurityCheck;
-import org.aerogear.mobile.security.SecurityCheckResult;
-import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
-
 /**
  * A check for whether the device the application is running on an emulator
  */

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/RootedCheck.java
@@ -5,12 +5,6 @@ import android.support.annotation.NonNull;
 
 import com.scottyab.rootbeer.RootBeer;
 
-import org.aerogear.mobile.security.SecurityCheck;
-import org.aerogear.mobile.security.SecurityCheckResult;
-import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
-
-import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
-
 /**
  * A check for whether the device the application is running on is rooted.
  */

--- a/auth/src/main/java/org/aerogear/mobile/security/checks/ScreenLockCheck.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/checks/ScreenLockCheck.java
@@ -5,13 +5,6 @@ import android.content.Context;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
-import org.aerogear.mobile.security.SecurityCheck;
-import org.aerogear.mobile.security.SecurityCheckResult;
-import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
-
-import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
-
-
 /**
  * A check for whether the device the application is running on has a screen lock.
  */

--- a/auth/src/test/java/org/aerogear/mobile/security/checks/AllowBackupFlagCheckTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/checks/AllowBackupFlagCheckTest.java
@@ -1,0 +1,51 @@
+package org.aerogear.mobile.security.checks;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import org.aerogear.mobile.security.SecurityCheckResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.robolectric.RuntimeEnvironment.application;
+
+@RunWith(RobolectricTestRunner.class)
+public class AllowBackupFlagCheckTest {
+
+    AllowBackupFlagCheck check;
+    PackageInfo packageInfo;
+
+    @Before
+    public void setup() throws PackageManager.NameNotFoundException {
+        check = new AllowBackupFlagCheck();
+        packageInfo = application.getPackageManager().getPackageInfo(application.getPackageName(), 0);
+    }
+
+    @Test
+    public void checkIsEnabled() throws PackageManager.NameNotFoundException {
+        // Set the allow backup flag
+        packageInfo.applicationInfo.flags = packageInfo.applicationInfo.flags | ApplicationInfo.FLAG_ALLOW_BACKUP;
+
+        SecurityCheckResult result = check.test(application);
+        assertTrue(result.passed());
+    }
+
+    @Test
+    public void checkNotEnabled() throws PackageManager.NameNotFoundException {
+        // Unset the allow backup flag
+        packageInfo.applicationInfo.flags = packageInfo.applicationInfo.flags & ~ApplicationInfo.FLAG_ALLOW_BACKUP;
+
+        SecurityCheckResult result = check.test(application);
+        assertFalse(result.passed());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void nullContextTest() {
+        check.test(null);
+    }
+}

--- a/example/src/main/java/org/aerogear/mobile/example/ui/SecurityServiceFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/SecurityServiceFragment.java
@@ -167,7 +167,10 @@ public class SecurityServiceFragment extends BaseFragment {
      */
     public void detectBackupEnabled(Map<String, SecurityCheckResult> results) {
         totalTests++;
-        //TODO: add check
+        SecurityCheckResult result = securityService.check(SecurityCheckType.ALLOW_BACKUP_ENABLED);
+        if(result.passed()) {
+            setDetected(allowBackup, R.string.allow_backup_detected_positive);
+        }
     }
 
     /**


### PR DESCRIPTION
## Motivation

Add a check for `allowBackup` flag.

JIRA: https://issues.jboss.org/browse/AEROGEAR-2208

## Description

Checks whether the `allowBackup` flag is enabled.

Also, addressing errors from linting.
## Progress

- [x] Check
- [x] Tests
- [x] JavaDoc
