### PR TITLE
Improve Logout Functionality

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -141,6 +141,14 @@ public class AuthService implements ServiceModule {
     }
 
     /**
+     * Delete the the current tokens/authentication state.
+     */
+    public void deleteTokens() {
+        failIfNotReady();
+        oidcAuthenticatorImpl.deleteTokens();
+    }
+
+    /**
      * This function should be called in the start activity's "onActivityResult" method to allow the SDK to process the response from the authentication server.
      * @param data The intent data that is passed to "onActivityResult"
      */

--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -153,10 +153,11 @@ public class AuthService implements ServiceModule {
      * The logout will be asynchronous.
      *
      * @param principal principal to be logged out
+     * @param callback the callback function to be invoked
      */
-    public void logout(@NonNull final UserPrincipal principal) {
+    public void logout(@NonNull final UserPrincipal principal, @NonNull final Callback<UserPrincipal> callback) {
         failIfNotReady();
-        this.oidcAuthenticatorImpl.logout(principal);
+        this.oidcAuthenticatorImpl.logout(principal, callback);
     }
 
 

--- a/auth/src/main/java/org/aerogear/mobile/auth/Callback.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/Callback.java
@@ -1,6 +1,7 @@
 package org.aerogear.mobile.auth;
 
 public interface Callback<T extends Object> {
-    void onSuccess(T models);
+    default void onSuccess() {}
+    default void onSuccess(T models) {onSuccess();}
     void onError(Throwable error);
 }

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/AbstractAuthenticator.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/AbstractAuthenticator.java
@@ -36,8 +36,9 @@ public abstract class AbstractAuthenticator {
      * Logout the given principal
      *
      * @param principal principal to be log out
+     * @param callback the callback function to be invoked
      */
-    public abstract void logout(final UserPrincipal principal);
+    public abstract void logout(final UserPrincipal principal, final Callback<UserPrincipal> callback);
 
     /**
      * Returns the authentication singleThreadService configuration

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
@@ -21,16 +21,21 @@ import org.aerogear.mobile.auth.credentials.OIDCCredentials;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.user.UserPrincipalImpl;
 import org.aerogear.mobile.auth.utils.UserIdentityParser;
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.http.HttpRequest;
+import org.aerogear.mobile.core.http.HttpResponse;
 import org.aerogear.mobile.core.http.HttpServiceModule;
 import org.aerogear.mobile.core.http.OkHttpServiceModule;
+import org.aerogear.mobile.core.logging.Logger;
 import org.jose4j.jwk.JsonWebKeySet;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
 /**
@@ -39,17 +44,13 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 public class OIDCAuthenticatorImpl extends AbstractAuthenticator {
 
     private AuthState authState;
-
     private AuthorizationService authService;
-
     private final KeycloakConfiguration keycloakConfiguration;
     private final AuthServiceConfiguration authServiceConfiguration;
-
     private Callback authCallback;
-
+    private Callback logoutCallback;
     private final AuthStateManager authStateManager;
     private final JwksManager jwksManager;
-
     private final AuthorizationServiceFactory authorizationServiceFactory;
 
     /**
@@ -145,7 +146,8 @@ public class OIDCAuthenticatorImpl extends AbstractAuthenticator {
     }
 
     @Override
-    public void logout(final UserPrincipal principal) {
+    public void logout(final UserPrincipal principal, final Callback<UserPrincipal> callback) {
+        this.logoutCallback = nonNull(callback, "callback");
         nonNull(principal, "principal");
 
         // Get user's identity token
@@ -169,15 +171,22 @@ public class OIDCAuthenticatorImpl extends AbstractAuthenticator {
         HttpRequest request = serviceModule.newRequest();
         request.get(logoutUrl.toString());
 
-        // Creates and handles the response
-        new AppExecutors().networkThread().execute(() -> request.execute());
-        //it doesn't matter if the logout request is successful or not, we should always delete the local tokens
-        //the remote session should be timed out eventually
-        authStateManager.save(null);
+        final HttpResponse httpResponse = request.execute();
+
+        httpResponse.onComplete(() -> {
+            if (httpResponse.getStatus() == HTTP_OK || httpResponse.getStatus() == HTTP_MOVED_TEMP) {
+                // delete the local tokens when the session with the OIDC has been terminated
+                authStateManager.save(null);
+                logoutCallback.onSuccess();
+            } else {
+                MobileCore.getLogger().error("Error Performing a Logout on the Remote OIDC Server: ", httpResponse.getRequestError());
+                logoutCallback.onError(httpResponse.getRequestError());
+            }
+        });
     }
 
     /**
-     * Constructs the logout url using the user's idenity token.
+     * Constructs the logout url using the user's identity token.
      *
      * @param identityToken {@link OIDCCredentials#getIdentityToken()}
      * @return the formatted logout url.

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
@@ -199,4 +199,11 @@ public class OIDCAuthenticatorImpl extends AbstractAuthenticator {
             throw new IllegalArgumentException("Could not parse logout url");
         }
     }
+
+    /**
+     * Delete the the current tokens/authentication state.
+     */
+    public void deleteTokens() {
+        authStateManager.clear();
+    }
 }

--- a/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
@@ -128,6 +128,9 @@ public class OIDCAuthenticatorImplTest {
 
     private OIDCAuthenticatorImpl authenticator;
 
+    @Mock
+    private OIDCAuthenticatorImpl authenticatorMock;
+
     private OIDCCredentials credential;
 
     private AuthServiceConfiguration authServiceConfiguration;
@@ -212,6 +215,11 @@ public class OIDCAuthenticatorImplTest {
             .withUsername("test-user")
             .withIdentityToken(identityToken)
             .build();
+
+        doAnswer(invocation -> {
+            ((Callback<UserPrincipal>)invocation.getArguments()[1]).onSuccess();
+            return null;
+        }).when(authenticatorMock).logout(any(), any(Callback.class));
     }
 
     @Test
@@ -236,9 +244,9 @@ public class OIDCAuthenticatorImplTest {
 
     @Test
     public void testLogout() {
-        authenticator.logout(userPrincipalImpl, new Callback<UserPrincipal>() {
+        authenticatorMock.logout(userPrincipalImpl, new Callback<UserPrincipal>() {
             @Override
-            public void onSuccess(UserPrincipal userPrincipal) {
+            public void onSuccess() {
                 Assert.assertEquals(null, authStateManager.load());
             }
 

--- a/docs/getting-started/auth.adoc
+++ b/docs/getting-started/auth.adoc
@@ -190,7 +190,7 @@ if (isModerator) {
 === Logging out
 
 To logout, invoke the `AuthService#logout` method. This accepts the `UserPrincipal` that was
-provided by `AuthService#handleAuthResponse`.
+provided by `AuthService#handleAuthResponse` and has a callback to determine if the logout to the Keycloak or OpenID Connect server was successful.
 
 [source,java]
 ----
@@ -198,8 +198,21 @@ provided by `AuthService#handleAuthResponse`.
 AuthService authService = mobileCore.getInstance(AuthService.class);
 UserPrincipal currentUser = authService.currentUser();
 
-authService.logout(currentUser);
+authService.logout(currentUser, new Callback<UserPrincipal>() {
+    @Override
+    public void onSuccess() {
+        // User Logged Out Successfully and Local Auth Tokens were Deleted
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        // An error occurred during logout
+    }
+});
 ----
+
+By default, the local tokens obtained during authentication are only deleted when the logout succeeded against the authentication server.
+You can use the `AuthService#deleteTokens` function to delete the local authentication tokens as part of a failed logout, or for other use cases.
 
 *Note:* To perform backchannel or federated logouts, you must enable the Backchannel Logout option for the federated identity provider. More information is available in the Keycloak documentation under  http://www.keycloak.org/docs/latest/server_admin/index.html#openid-connect-v1-0-identity-providers[OIDC Identity Providers].
 

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthDetailsFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthDetailsFragment.java
@@ -90,7 +90,7 @@ public class AuthDetailsFragment extends BaseFragment {
     }
 
     /**
-     * Show a snackbar message to show
+     * Show a snackbar message
      *
      * @param message the message to show in the snackbar
      */


### PR DESCRIPTION
## Motivation
Detail in https://github.com/aerogear/aerogear-android-sdk/issues/96
Improves usage experience for - https://github.com/feedhenry/mobile-security-android-template/pull/36

## Description
Adding a callback for the logout function so it lets the user know if the logout has succeeded or not. 

## Progress
- [x] Add Logout Callbacks https://github.com/aerogear/aerogear-android-sdk/pull/118/commits/8b08cbe4201d0f65fd5dca69f420a55a9852b6a3
- [x] Update Example App to use Logout Callbacks https://github.com/aerogear/aerogear-android-sdk/pull/118/commits/8b08cbe4201d0f65fd5dca69f420a55a9852b6a3
- [x] Expose a `deleteTokens()` function to handle offline logouts or other. https://github.com/aerogear/aerogear-android-sdk/pull/118/commits/7bf77a429580c2553a9c197244985e0665328237
- [x] Update Docs https://github.com/aerogear/aerogear-android-sdk/pull/118/commits/bbbebe60de80b03fd2953ea46879833c38dcbd75
- [x] Create logout test. https://github.com/aerogear/aerogear-android-sdk/pull/118/commits/62ca6bbdad72aba2e530f56062adaad87993ae8e

## Additional Notes
Updated the Callback interface so that onSuccess can be called without the requirement to pass some data.
