### PR TITLE
implement http error handling

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
@@ -9,7 +9,9 @@ package org.aerogear.mobile.core.http;
 public interface HttpResponse {
 
     /**
-     * Creates a callback to be called when the response is finished successfully.
+     * Creates a callback to be called when the response is finished (successful or unsuccessful).
+     * This will be called, even if success and error handlers are registered. onComplete will
+     * be called last.
      *
      * The response is delivered immediately if the request has already been finished.
      *
@@ -28,6 +30,16 @@ public interface HttpResponse {
      * @return the instance of the HttpResponse for API chaining
      */
     HttpResponse onError(Runnable runnable);
+
+    /**
+     * Creates a callback to be called when the request has succeeded.
+     *
+     * This will be triggered when the request succeeded and received a non-error status code.
+     *
+     * @param runnable a callback method
+     * @return the instance of the HttpResponse for API chaining
+     */
+    HttpResponse onSuccess(Runnable runnable);
 
     /**
      * Returns the HTTP status code of the response.
@@ -50,16 +62,8 @@ public interface HttpResponse {
     String stringBody();
 
     /**
-     * Returns true if the requests failed. Use getStatus to identify
-     * the reason
-     *
-     * @return true if request failed
-     */
-    boolean requestFailed();
-
-    /**
      * Returns the request error if it failed
      * @return Exception request error or null
      */
-    Exception getRequestError();
+    Exception getError();
 }

--- a/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
@@ -19,6 +19,17 @@ public interface HttpResponse {
     HttpResponse onComplete(Runnable runnable);
 
     /**
+     * Creates a callback to be called when the request has failed.
+     *
+     * This will be triggered when the request could not be sent or no response can be
+     * received.
+     *
+     * @param runnable a callback method
+     * @return the instance of the HttpResponse for API chaining
+     */
+    HttpResponse onError(Runnable runnable);
+
+    /**
      * Returns the HTTP status code of the response.
      *
      * @return the status code.

--- a/core/src/main/java/org/aerogear/mobile/core/http/InvalidResponseException.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/InvalidResponseException.java
@@ -1,0 +1,18 @@
+package org.aerogear.mobile.core.http;
+
+/**
+ * Custom exception thrown when a http request returns an unenxpected
+ * result or result code
+ */
+public class InvalidResponseException extends RuntimeException {
+    private final int statusCode;
+
+    public InvalidResponseException(int statusCode) {
+        super("Unexpected response from server. Status code was: " + statusCode);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -52,11 +52,11 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
             MobileCore.getLogger().debug("Sending metrics");
 
             final HttpResponse httpResponse = httpRequest.execute();
-            httpResponse.onComplete(() -> {
+            httpResponse.onSuccess(() -> {
                 MobileCore.getLogger().debug("Metrics sent: " + json.toString());
             }).onError(() -> {
                 MobileCore.getLogger().error("Metrics request error",
-                    httpResponse.getRequestError());
+                    httpResponse.getError());
             });
 
         } catch (JSONException e) {

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -11,7 +11,6 @@ import org.aerogear.mobile.core.utils.ClientIdGenerator;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
 /**

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -54,12 +54,10 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
 
             final HttpResponse httpResponse = httpRequest.execute();
             httpResponse.onComplete(() -> {
-                if (httpResponse.getStatus() == HTTP_OK) {
-                    MobileCore.getLogger().debug("Metrics sent: " + json.toString());
-                } else {
-                    MobileCore.getLogger().error(httpResponse.getRequestError().getMessage(),
-                        httpResponse.getRequestError());
-                }
+                MobileCore.getLogger().debug("Metrics sent: " + json.toString());
+            }).onError(() -> {
+                MobileCore.getLogger().error("Metrics request error",
+                    httpResponse.getRequestError());
             });
 
         } catch (JSONException e) {

--- a/core/src/test/java/org/aerogear/mobile/core/MobileCoreTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/MobileCoreTest.java
@@ -256,6 +256,9 @@ public class MobileCoreTest {
                         public HttpResponse onError(Runnable runnable) { return this; }
 
                         @Override
+                        public HttpResponse onSuccess(Runnable runnable) { return this; }
+
+                        @Override
                         public int getStatus() {
                             return HTTP_OK;
                         }
@@ -270,12 +273,7 @@ public class MobileCoreTest {
                         }
 
                         @Override
-                        public boolean requestFailed() {
-                            return false;
-                        }
-
-                        @Override
-                        public Exception getRequestError() {
+                        public Exception getError() {
                             return null;
                         }
                     };

--- a/core/src/test/java/org/aerogear/mobile/core/MobileCoreTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/MobileCoreTest.java
@@ -253,6 +253,9 @@ public class MobileCoreTest {
                         }
 
                         @Override
+                        public HttpResponse onError(Runnable runnable) { return this; }
+
+                        @Override
                         public int getStatus() {
                             return HTTP_OK;
                         }

--- a/core/src/test/java/org/aerogear/mobile/core/http/OkHttpServiceModuleTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/http/OkHttpServiceModuleTest.java
@@ -2,6 +2,8 @@ package org.aerogear.mobile.core.http;
 
 import android.support.test.filters.SmallTest;
 
+import junit.framework.Assert;
+
 import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;
 import org.aerogear.mobile.core.http.HttpServiceModule;
@@ -39,6 +41,28 @@ public class OkHttpServiceModuleTest {
             "     \"title\": \"Test Title\"\n" +
             " }    \n" +
             "}", response.stringBody()));
+
+        response.waitForCompletionAndClose();
+    }
+
+    @Test
+    public void testCompleteHandlerNotCalledInErrorCase() {
+        HttpServiceModule module = new OkHttpServiceModule();
+
+        HttpRequest request = module.newRequest();
+        request.get("http://does.not.exist.com");
+
+        final HttpResponse response = request.execute();
+        assertNotNull(response);
+
+        response.onComplete(() -> {
+            // The complete handler must not be called here
+            Assert.fail("The complete handler must not be called here");
+        });
+
+        response.onError(() -> {
+            assertNotNull(response.getRequestError());
+        });
 
         response.waitForCompletionAndClose();
     }

--- a/core/src/test/java/org/aerogear/mobile/core/http/OkHttpServiceModuleTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/http/OkHttpServiceModuleTest.java
@@ -4,14 +4,11 @@ import android.support.test.filters.SmallTest;
 
 import junit.framework.Assert;
 
-import org.aerogear.mobile.core.http.HttpRequest;
-import org.aerogear.mobile.core.http.HttpResponse;
-import org.aerogear.mobile.core.http.HttpServiceModule;
-import org.aerogear.mobile.core.http.OkHttpServiceModule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -56,8 +53,7 @@ public class OkHttpServiceModuleTest {
         assertNotNull(response);
 
         response.onComplete(() -> {
-            // The complete handler must not be called here
-            Assert.fail("The complete handler must not be called here");
+            fail("The complete handler must not be called here");
         });
 
         response.onError(() -> {
@@ -66,5 +62,4 @@ public class OkHttpServiceModuleTest {
 
         response.waitForCompletionAndClose();
     }
-
 }


### PR DESCRIPTION
## Motivation

Allow better error handling when using the http module and fix a bug in the metrics module. When the return code from a request was 500 the `onComplete` handler was triggered. The metrics module tried to evaluate the `requestError` but it was null. The current implementation does set the `requestError` only when the request itself failed, not when the response returned an invalid status code.

Example:

```java
final HttpResponse resp = httpRequest.execute();
resp.onSuccess(() -> {
  // Do something with the result           
}).onError(() -> {
  // Print an error message, you can safely access resp.getRequestError()
}).onComplete() -> {
  // Close any resources, popups... This will always be called
});
```

## Description

Adds `onError` and `onSuccess` handlers to the `HttpResponse` objects. I've looked at the OkHttp recipes (https://github.com/square/okhttp/wiki/Recipes) and they seem to suggest a similar pattern for error handling.

Tested with:

- successful request
- request that returns status 500
- request to invalid URL

## Progress

- [x] Done Task
