### PR TITLE
[AGDROID-771] Batch security metrics and update json schema

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -23,7 +23,10 @@ android {
     }
 
     testOptions {
-        unitTests.includeAndroidResources = true
+        unitTests {
+            includeAndroidResources = true
+            returnDefaultValues = true
+        }
     }
 }
 

--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -5,12 +5,12 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 
 import org.aerogear.mobile.auth.authenticator.AuthorizationServiceFactory;
+import org.aerogear.mobile.auth.authenticator.DefaultAuthenticateOptions;
+import org.aerogear.mobile.auth.authenticator.oidc.OIDCAuthenticatorImpl;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
-import org.aerogear.mobile.auth.authenticator.DefaultAuthenticateOptions;
 import org.aerogear.mobile.auth.credentials.JwksManager;
 import org.aerogear.mobile.auth.credentials.OIDCCredentials;
-import org.aerogear.mobile.auth.authenticator.oidc.OIDCAuthenticatorImpl;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.utils.UserIdentityParser;
 import org.aerogear.mobile.core.MobileCore;

--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -40,7 +40,8 @@ public class AuthService implements ServiceModule {
     private OIDCAuthenticatorImpl oidcAuthenticatorImpl;
 
     private Context appContext;
-    private Logger logger;
+    private final Logger LOG = MobileCore.getLogger();
+    private final String TAG = "AuthService";
     private JwksManager jwksManager;
 
     private MobileCore mobileCore;
@@ -120,7 +121,7 @@ public class AuthService implements ServiceModule {
                     UserIdentityParser parser = new UserIdentityParser(currentCredentials, keycloakConfiguration);
                     currentUser = parser.parseUser();
                 } catch (AuthenticationException ae) {
-                    logger.error("Failed to parse user identity from credential", ae);
+                    LOG.error(TAG, "Failed to parse user identity from credential", ae);
                     currentUser = null;
                 }
             }
@@ -167,7 +168,6 @@ public class AuthService implements ServiceModule {
 
     @Override
     public void configure(final MobileCore core, final ServiceConfiguration serviceConfiguration) {
-        this.logger = MobileCore.getLogger();
         this.mobileCore = nonNull(core, "mobileCore");
         this.serviceConfiguration = nonNull(serviceConfiguration, "serviceConfiguration");
         this.keycloakConfiguration = new KeycloakConfiguration(serviceConfiguration);

--- a/auth/src/main/java/org/aerogear/mobile/auth/configuration/KeycloakConfiguration.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/configuration/KeycloakConfiguration.java
@@ -4,8 +4,8 @@ import android.net.Uri;
 
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 
-import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 import static org.aerogear.mobile.core.utils.SanityCheck.nonEmpty;
+import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
 /**
  * A class to represent the configuration options of the Keycloak singleThreadService

--- a/auth/src/main/java/org/aerogear/mobile/auth/credentials/OIDCCredentials.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/credentials/OIDCCredentials.java
@@ -9,7 +9,6 @@ import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
 import org.jose4j.jwa.AlgorithmConstraints;
 import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jws.AlgorithmIdentifiers;
-import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.ErrorCodeValidator;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.JwtConsumer;
@@ -62,7 +61,7 @@ public class OIDCCredentials {
 
     /**
      * Verify the token and its claims against the given Keycloak configuration
-     * 
+     *
      * @param jwks json web keys to verify
      * @param keycloakConfig keycloak config containing certificate information for the jwks instance.
      * @return true if the jwks value is valid, false otherwise

--- a/auth/src/main/java/org/aerogear/mobile/auth/user/UserPrincipal.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/user/UserPrincipal.java
@@ -1,7 +1,6 @@
 package org.aerogear.mobile.auth.user;
 
 import java.io.Serializable;
-import java.security.Principal;
 import java.util.Set;
 
 /**

--- a/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
@@ -60,12 +60,25 @@ abstract class AbstractSecurityCheckExecutor<T extends AbstractSecurityCheckExec
     }
 
     /**
-     * Gets the metrics service.
+     * Gets the metric published. It never returns null: if no metric service is present, e NOOP publisher
+     * is returned.
      *
-     * @return {@link MetricsService}
+     * @return the metric service publisher
      */
-    protected MetricsService getMetricsService() {
-        return metricsService;
+    protected SecurityCheckExecutorListener getMetricServicePublisher() {
+        if (metricsService != null) {
+            return new SecurityCheckMetricPublisher(metricsService);
+        } else {
+            return new SecurityCheckExecutorListener() {
+                @Override
+                public void onExecuted(SecurityCheckResult result) {
+                }
+
+                @Override
+                public void onFinished() {
+                }
+            };
+        }
     }
 
     /**

--- a/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
@@ -75,7 +75,7 @@ abstract class AbstractSecurityCheckExecutor<T extends AbstractSecurityCheckExec
                 }
 
                 @Override
-                public void onFinished() {
+                public void onComplete() {
                 }
             };
         }

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -4,9 +4,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.executor.AppExecutors;
-import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.MetricsService;
 
 import java.util.ArrayList;
@@ -132,7 +130,7 @@ public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<As
                     listener.onExecuted(result);
 
                     if (remaining <= 0) {
-                        listener.onFinished();
+                        listener.onComplete();
                     }
                 }
 

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -98,10 +98,23 @@ public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<As
      * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
      * a {@link Map} of {@link Future} with the {@link SecurityCheckResult} of the check.
      *
+     * @return {@link Map}
+     */
+    public Map<String, Future<SecurityCheckResult>> execute() {
+        return execute(new SecurityCheckExecutorListener[0]);
+    }
+
+    /**
+     * Executes the checks asynchronously.
+     *
+     * Returns a {@link Map} containing the results of each executed test (a {@link Future}).
+     * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
+     * a {@link Map} of {@link Future} with the {@link SecurityCheckResult} of the check.
+     *
      * @param securityCheckExecutorListeners list of listeners that will receive events about checks execution
      * @return {@link Map}
      */
-    public Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
+    private Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
 
         final List<SecurityCheckExecutorListener> listeners =
             securityCheckExecutorListeners == null ? new ArrayList<>(1) : new ArrayList(Arrays.asList(securityCheckExecutorListeners));

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -8,7 +8,6 @@ import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.MetricsService;
-import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,9 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Checks are executed by using {@link AppExecutors#singleThreadService()} if no custom executor is configured.
  */
 public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<AsyncSecurityCheckExecutor> {
-
-    private final static String TAG = "AsyncSecurityCheckExecutor";
-    private final static Logger LOG = MobileCore.getLogger();
 
     private final ExecutorService executorService;
 
@@ -117,7 +113,7 @@ public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<As
     private Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
 
         final List<SecurityCheckExecutorListener> listeners =
-            securityCheckExecutorListeners == null ? new ArrayList<>(1) : new ArrayList(Arrays.asList(securityCheckExecutorListeners));
+            securityCheckExecutorListeners == null ? new ArrayList<>(1) : new ArrayList<>(Arrays.asList(securityCheckExecutorListeners));
         final Collection<SecurityCheck> checks = getChecks();
 
         // Adds the metric publisher to the passed in listeners

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -103,22 +103,17 @@ public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<As
      */
     public Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
 
-        final List<SecurityCheckExecutorListener> listeners;
+        final List<SecurityCheckExecutorListener> listeners =
+            securityCheckExecutorListeners == null ? new ArrayList<>(1) : new ArrayList(Arrays.asList(securityCheckExecutorListeners));
         final Collection<SecurityCheck> checks = getChecks();
 
-        // Initializes listener list: the metric publisher will be added to passed in listeners
-        if (securityCheckExecutorListeners == null) {
-            listeners = new ArrayList<>(1);
-        } else {
-            listeners = new ArrayList(Arrays.asList(securityCheckExecutorListeners));
-        }
-
+        // Adds the metric publisher to the passed in listeners
         listeners.add(getMetricServicePublisher());
 
         final Map<String, Future<SecurityCheckResult>> res = new HashMap<>();
         final AtomicInteger count = new AtomicInteger(checks.size());
 
-        for (final SecurityCheck check : getChecks()) {
+        for (final SecurityCheck check : checks) {
             res.put(check.getName(), (executorService.submit(() -> {
                 final SecurityCheckResult result =  check.test(getContext());
 

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutorListener.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutorListener.java
@@ -1,0 +1,20 @@
+package org.aerogear.mobile.security;
+
+import org.aerogear.mobile.security.SecurityCheckResult;
+
+/**
+ * Listener for events about check execution.
+ */
+public interface SecurityCheckExecutorListener {
+
+    /**
+     * Called after each check is executed
+     * @param result the result of the check
+     */
+    void onExecuted(SecurityCheckResult result);
+
+    /**
+     * Called when all submitted checks has been executed.
+     */
+    void onFinished();
+}

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutorListener.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutorListener.java
@@ -1,7 +1,5 @@
 package org.aerogear.mobile.security;
 
-import org.aerogear.mobile.security.SecurityCheckResult;
-
 /**
  * Listener for events about check execution.
  */
@@ -16,5 +14,5 @@ public interface SecurityCheckExecutorListener {
     /**
      * Called when all submitted checks has been executed.
      */
-    void onFinished();
+    void onComplete();
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -13,7 +13,7 @@ import java.util.List;
 class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
 
     private final MetricsService metricsService;
-    private final List<SecurityCheckResultMetric> metrics = new ArrayList<>();
+    private final List<SecurityCheckResult> metricResults = new ArrayList<>();
 
     /**
      * Builds the object.
@@ -26,11 +26,11 @@ class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
 
     @Override
     public synchronized void onExecuted(SecurityCheckResult result) {
-        metrics.add(new SecurityCheckResultMetric(result));
+        metricResults.add(result);
     }
 
     @Override
     public synchronized void onFinished() {
-        metricsService.publish(metrics.toArray(new SecurityCheckResultMetric[metrics.size()]));
+        metricsService.publish(new SecurityCheckResultMetric(metricResults));
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -1,0 +1,36 @@
+package org.aerogear.mobile.security;
+
+
+import org.aerogear.mobile.core.metrics.MetricsService;
+import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This object will manage the communication with the metric service, batching the results to be published.
+ */
+class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
+
+    private final MetricsService metricsService;
+    private final List<SecurityCheckResultMetric> metrics = new ArrayList<>();
+
+    /**
+     * Builds the object.
+     *
+     * @param metricsService metric service to be used to publish the metrics
+     */
+    SecurityCheckMetricPublisher(final MetricsService metricsService) {
+        this.metricsService = metricsService;
+    }
+
+    @Override
+    public synchronized void onExecuted(SecurityCheckResult result) {
+        metrics.add(new SecurityCheckResultMetric(result));
+    }
+
+    @Override
+    public synchronized void onFinished() {
+        metricsService.publish(metrics.toArray(new SecurityCheckResultMetric[metrics.size()]));
+    }
+}

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -30,7 +30,7 @@ class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
     }
 
     @Override
-    public synchronized void onFinished() {
+    public synchronized void onComplete() {
         metricsService.publish(new SecurityCheckResultMetric(metricResults));
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckType.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckType.java
@@ -2,8 +2,8 @@ package org.aerogear.mobile.security;
 
 
 import org.aerogear.mobile.security.checks.AllowBackupFlagCheck;
-import org.aerogear.mobile.security.checks.DeveloperModeCheck;
 import org.aerogear.mobile.security.checks.DebuggerCheck;
+import org.aerogear.mobile.security.checks.DeveloperModeCheck;
 import org.aerogear.mobile.security.checks.EmulatorCheck;
 import org.aerogear.mobile.security.checks.EncryptionCheck;
 import org.aerogear.mobile.security.checks.RootedCheck;

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -126,7 +126,7 @@ public class SecurityService implements ServiceModule {
      * @throws IllegalArgumentException if metricsService is null
      */
     public SecurityCheckResult checkAndSendMetric(final SecurityCheck securityCheck, @NonNull final MetricsService metricsService) {
-        SecurityCheckResult result = check(securityCheck);
+        final SecurityCheckResult result = check(securityCheck);
         nonNull(metricsService, "metricsService").publish(new SecurityCheckResultMetric(result));
         return result;
     }

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -70,26 +70,17 @@ public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<Syn
     public Map<String, SecurityCheckResult> execute() {
         final Map<String, SecurityCheckResult> results = new HashMap<>();
 
+        final SecurityCheckExecutorListener metricServicePublisher = getMetricServicePublisher();
+
         for (SecurityCheck check : getChecks()) {
             SecurityCheckResult result = check.test(getContext());
             results.put(check.getName(), result);
-            publishResultMetrics(result);
+
+            metricServicePublisher.onExecuted(result);
         }
+
+        metricServicePublisher.onFinished();
 
         return results;
-    }
-
-    /**
-     * Publish each result provided as an {@link SecurityCheckResultMetric}.
-     *
-     * @param result {@link SecurityCheckResult} to be published
-     * @throws IllegalArgumentException if result is null
-     */
-    private void publishResultMetrics(@NonNull SecurityCheckResult result) {
-        MetricsService metricsService = getMetricsService();
-
-        if (metricsService != null) {
-            metricsService.publish(new SecurityCheckResultMetric(nonNull(result, "result")));
-        }
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -11,8 +11,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
-
 /**
  * Synchronously executes provided {@link SecurityCheck}s.
  */

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.aerogear.mobile.core.metrics.MetricsService;
-import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -77,7 +76,7 @@ public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<Syn
             metricServicePublisher.onExecuted(result);
         }
 
-        metricServicePublisher.onFinished();
+        metricServicePublisher.onComplete();
 
         return results;
     }

--- a/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
@@ -3,6 +3,7 @@ package org.aerogear.mobile.security.metrics;
 import android.support.annotation.NonNull;
 
 import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.security.SecurityCheckResult;
 import org.json.JSONException;
@@ -18,6 +19,8 @@ public class SecurityCheckResultMetric implements Metrics {
 
     private final String identifier = "security";
     private final JSONObject data;
+    private final Logger LOG = MobileCore.getLogger();
+    private final String TAG = "SecurityCheckResultMetric";
 
     /**
      * Creates a SecurityCheckResultMetric object.
@@ -75,7 +78,7 @@ public class SecurityCheckResultMetric implements Metrics {
             data.put("passed", result.passed());
         } catch (JSONException e) {
             // should never happen since we're building from scratch
-            MobileCore.getLogger().error("Error building JSON from Self Defence Check result", e);
+            LOG.error(TAG,"Error building JSON from Self Defence Check result", e);
         }
         return data;
     }

--- a/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
@@ -2,15 +2,13 @@ package org.aerogear.mobile.security.metrics;
 
 import android.support.annotation.NonNull;
 
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.security.SecurityCheckResult;
+import org.json.JSONException;
+import org.json.JSONObject;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-
-import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
 /**
  * Metric representation of {@link SecurityCheckResult}. This is intended to be used with the
@@ -19,7 +17,7 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 public class SecurityCheckResultMetric implements Metrics {
 
     private final String identifier = "security";
-    private final Map<String, String> data;
+    private final JSONObject data;
 
     /**
      * Creates a SecurityCheckResultMetric object.
@@ -60,8 +58,9 @@ public class SecurityCheckResultMetric implements Metrics {
      * the value is <code>true</code> if the check result passed
      */
     @Override
-    public Map<String, String> data() {
-        return Collections.unmodifiableMap(data);
+    public JSONObject data() {
+        // TODO: consider returning a deep clone
+        return data;
     }
 
     /**
@@ -70,9 +69,14 @@ public class SecurityCheckResultMetric implements Metrics {
      * @param result the {@link SecurityCheckResult} of the test executed
      * @return {@link Map} data
      */
-    private Map<String, String> getDataFromResult(final SecurityCheckResult result) {
-        final Map<String, String> data = new HashMap<>();
-        data.put("passed", String.valueOf(result.passed()));
+    private JSONObject getDataFromResult(final SecurityCheckResult result) {
+        final JSONObject data = new JSONObject();
+        try {
+            data.put("passed", result.passed());
+        } catch (JSONException e) {
+            // should never happen since we're building from scratch
+            MobileCore.getLogger().error("Error building JSON from Self Defence Check result", e);
+        }
         return data;
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
@@ -6,9 +6,11 @@ import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.security.SecurityCheckResult;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -17,10 +19,13 @@ import java.util.Map;
  */
 public class SecurityCheckResultMetric implements Metrics {
 
-    private final String identifier = "security";
-    private final JSONObject data;
+    private final JSONArray data;
     private final Logger LOG = MobileCore.getLogger();
     private final String TAG = "SecurityCheckResultMetric";
+
+    public static final String IDENTIFIER = "security";
+    public static final String KEY_TYPE = "type";
+    public static final String KEY_VALUE = "passed";
 
     /**
      * Creates a SecurityCheckResultMetric object.
@@ -30,7 +35,7 @@ public class SecurityCheckResultMetric implements Metrics {
      *
      */
     public SecurityCheckResultMetric(@NonNull final Iterable<SecurityCheckResult> results) {
-        this.data = getDataFromResult(results.iterator().next());
+        this.data = getDataFromResult(results);
     }
 
     /**
@@ -41,7 +46,7 @@ public class SecurityCheckResultMetric implements Metrics {
      *
      */
     public SecurityCheckResultMetric(@NonNull final SecurityCheckResult... results) {
-        this.data = getDataFromResult(results[0]);
+        this.data = getDataFromResult(Arrays.asList(results));
     }
 
     /**
@@ -51,7 +56,7 @@ public class SecurityCheckResultMetric implements Metrics {
      */
     @Override
     public String identifier() {
-        return identifier;
+        return IDENTIFIER;
     }
 
     /**
@@ -61,7 +66,7 @@ public class SecurityCheckResultMetric implements Metrics {
      * the value is <code>true</code> if the check result passed
      */
     @Override
-    public JSONObject data() {
+    public JSONArray data() {
         // TODO: consider returning a deep clone
         return data;
     }
@@ -69,17 +74,24 @@ public class SecurityCheckResultMetric implements Metrics {
     /**
      * Creates the data structure that stores whether or not the result passed or not.
      *
-     * @param result the {@link SecurityCheckResult} of the test executed
+     * @param results the {@link SecurityCheckResult} iterable of the test executed
      * @return {@link Map} data
      */
-    private JSONObject getDataFromResult(final SecurityCheckResult result) {
-        final JSONObject data = new JSONObject();
+    private JSONArray getDataFromResult(final Iterable<SecurityCheckResult> results) {
+        final JSONArray data = new JSONArray();
+
         try {
-            data.put("passed", result.passed());
+            for (SecurityCheckResult result: results) {
+                final JSONObject resultJson = new JSONObject();
+                resultJson.put(KEY_TYPE, result.getName());
+                resultJson.put(KEY_VALUE, result.passed());
+                data.put(resultJson);
+            }
         } catch (JSONException e) {
             // should never happen since we're building from scratch
             LOG.error(TAG,"Error building JSON from Self Defence Check result", e);
         }
+
         return data;
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.security.SecurityCheckResult;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,18 +18,29 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
  */
 public class SecurityCheckResultMetric implements Metrics {
 
-    private final String identifier;
+    private final String identifier = "security";
     private final Map<String, String> data;
 
     /**
      * Creates a SecurityCheckResultMetric object.
      *
-     * @param result the {@link SecurityCheckResult} of the test executed
+     * @param results the list of {@link SecurityCheckResult} of the tests executed
      * @throws IllegalArgumentException if result is null
+     *
      */
-    public SecurityCheckResultMetric(@NonNull final SecurityCheckResult result) {
-        this.identifier = nonNull(result, "result").getName();
-        this.data = getDataFromResult(result);
+    public SecurityCheckResultMetric(@NonNull final Iterable<SecurityCheckResult> results) {
+        this.data = getDataFromResult(results.iterator().next());
+    }
+
+    /**
+     * Creates a SecurityCheckResultMetric object.
+     *
+     * @param results the list of {@link SecurityCheckResult} of the tests executed
+     * @throws IllegalArgumentException if result is null
+     *
+     */
+    public SecurityCheckResultMetric(@NonNull final SecurityCheckResult... results) {
+        this.data = getDataFromResult(results[0]);
     }
 
     /**

--- a/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * Metric representation of {@link SecurityCheckResult}. This is intended to be used with the
  * {@link org.aerogear.mobile.core.metrics.MetricsService}.
  */
-public class SecurityCheckResultMetric implements Metrics {
+public class SecurityCheckResultMetric implements Metrics<JSONArray> {
 
     private final JSONArray data;
     private final Logger LOG = MobileCore.getLogger();
@@ -62,8 +62,7 @@ public class SecurityCheckResultMetric implements Metrics {
     /**
      * Gets the data from the result which contains whether the check passed or not.
      *
-     * @return {@link Map} where the key is a {@link String} and
-     * the value is <code>true</code> if the check result passed
+     * @return {@link JSONArray} containing the results for self-defence checks
      */
     @Override
     public JSONArray data() {
@@ -75,7 +74,7 @@ public class SecurityCheckResultMetric implements Metrics {
      * Creates the data structure that stores whether or not the result passed or not.
      *
      * @param results the {@link SecurityCheckResult} iterable of the test executed
-     * @return {@link Map} data
+     * @return {@link JSONArray} data
      */
     private JSONArray getDataFromResult(final Iterable<SecurityCheckResult> results) {
         final JSONArray data = new JSONArray();

--- a/auth/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
@@ -2,6 +2,7 @@ package org.aerogear.mobile.security;
 
 import android.content.Context;
 
+import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.metrics.MetricsService;
 import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
 import org.junit.Before;
@@ -10,8 +11,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
@@ -103,6 +106,9 @@ public class SecurityCheckExecutorTest {
         assertTrue(results.containsKey(mockSecurityCheck.getName()));
         results.get(mockSecurityCheck.getName()).get();
 
-        verify(metricsService, times(1)).publish(any());
+        ExecutorService executorService = (new AppExecutors()).networkThread();
+        executorService.submit(() -> verify(metricsService, times(1)).publish(any()));
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
+        executorService.shutdown();
     }
 }

--- a/auth/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
@@ -79,7 +79,7 @@ public class SecurityCheckExecutorTest {
     @Test
     public void testExecuteAsync() throws Exception {
 
-        Map<String, Future<SecurityCheckResult>> results = SecurityCheckExecutor.Builder
+        final Map<String, Future<SecurityCheckResult>> results = SecurityCheckExecutor.Builder
             .newAsyncExecutor(context)
             .withSecurityCheck(securityCheckType)
             .withExecutorService(Executors.newFixedThreadPool(1))
@@ -94,7 +94,7 @@ public class SecurityCheckExecutorTest {
     public void testSendMetricsAsync() throws Exception {
         when(metricsService.publish(any())).thenReturn(null);
 
-        Map<String, Future<SecurityCheckResult>> results = SecurityCheckExecutor.Builder
+        final Map<String, Future<SecurityCheckResult>> results = SecurityCheckExecutor.Builder
             .newAsyncExecutor(context)
             .withSecurityCheck(securityCheckType)
             .withMetricsService(metricsService)

--- a/auth/src/test/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetricTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetricTest.java
@@ -3,6 +3,7 @@ package org.aerogear.mobile.security.metrics;
 import org.aerogear.mobile.security.SecurityCheck;
 import org.aerogear.mobile.security.SecurityCheckResult;
 import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
+import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,9 +29,9 @@ public class SecurityCheckResultMetricTest {
     }
 
     @Test
-    public void testConversion() {
+    public void testConversion() throws JSONException {
         SecurityCheckResultMetric metric = new SecurityCheckResultMetric(result);
         assertEquals(securityCheck.getName(), metric.identifier());
-        assertEquals(String.valueOf(RESULT_PASSED), metric.data().get("passed"));
+        assertEquals(RESULT_PASSED, metric.data().getBoolean("passed"));
     }
 }

--- a/auth/src/test/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetricTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetricTest.java
@@ -3,7 +3,9 @@ package org.aerogear.mobile.security.metrics;
 import org.aerogear.mobile.security.SecurityCheck;
 import org.aerogear.mobile.security.SecurityCheckResult;
 import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
+import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,26 +14,40 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class SecurityCheckResultMetricTest {
 
-    SecurityCheckResult result;
-    final static boolean RESULT_PASSED = true;
+    SecurityCheckResult okResult;
+    SecurityCheckResult failedResult;
 
     @Mock
     private SecurityCheck securityCheck;
+    private final String NAME = "TestCheck";
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        result = new SecurityCheckResultImpl(securityCheck, RESULT_PASSED);
+        when(securityCheck.getName()).thenReturn(NAME);
+        okResult = new SecurityCheckResultImpl(securityCheck, true);
+        failedResult = new SecurityCheckResultImpl(securityCheck, false);
     }
 
     @Test
     public void testConversion() throws JSONException {
-        SecurityCheckResultMetric metric = new SecurityCheckResultMetric(result);
-        assertEquals(securityCheck.getName(), metric.identifier());
-        assertEquals(RESULT_PASSED, metric.data().getBoolean("passed"));
+        SecurityCheckResultMetric metric = new SecurityCheckResultMetric(okResult, failedResult);
+        assertEquals(SecurityCheckResultMetric.IDENTIFIER, metric.identifier());
+
+        JSONArray data = metric.data();
+        JSONObject okResultJson = data.getJSONObject(0);
+        JSONObject failedResultJson = data.getJSONObject(1);
+
+        assertEquals(NAME, okResultJson.get(SecurityCheckResultMetric.KEY_TYPE));
+        assertEquals(true, okResultJson.getBoolean(SecurityCheckResultMetric.KEY_VALUE));
+
+        assertEquals(NAME, failedResultJson.get(SecurityCheckResultMetric.KEY_TYPE));
+        assertEquals(false, failedResultJson.getBoolean(SecurityCheckResultMetric.KEY_VALUE));
     }
 }

--- a/core/src/main/java/org/aerogear/mobile/core/executor/AppExecutors.java
+++ b/core/src/main/java/org/aerogear/mobile/core/executor/AppExecutors.java
@@ -13,7 +13,7 @@ import java.util.concurrent.Executors;
  */
 public final class AppExecutors {
 
-    private static final Executor networkExecutor = Executors.newSingleThreadExecutor();
+    private static final ExecutorService networkExecutor = Executors.newSingleThreadExecutor();
 
     private static final Executor mainThreadExecutor = new Executor() {
         private Handler mainThreadHandler = new Handler(Looper.getMainLooper());
@@ -34,7 +34,7 @@ public final class AppExecutors {
         return mainThreadExecutor;
     }
 
-    public Executor networkThread() {
+    public ExecutorService networkThread() {
         return networkExecutor;
     }
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/Metrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/Metrics.java
@@ -1,9 +1,23 @@
 package org.aerogear.mobile.core.metrics;
 
-public interface Metrics {
+import org.json.JSONObject;
 
+/**
+ * Interface for a record to be published to the metrics service
+ * @param <T> A type that can be serialized into a {@link JSONObject} value
+ */
+public interface Metrics<T> {
+
+    /**
+     * The key to identify this record inside the metrics payload
+     * @return A string identifying the payload
+     */
     String identifier();
 
-    Object data();
+    /**
+     * The data to be included under the identifier key in the metrics payload
+     * @return The serializable data object
+     */
+    T data();
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/Metrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/Metrics.java
@@ -1,11 +1,11 @@
 package org.aerogear.mobile.core.metrics;
 
-import java.util.Map;
+import org.json.JSONObject;
 
 public interface Metrics {
 
     String identifier();
 
-    Map<String, String> data();
+    JSONObject data();
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/Metrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/Metrics.java
@@ -1,11 +1,9 @@
 package org.aerogear.mobile.core.metrics;
 
-import org.json.JSONObject;
-
 public interface Metrics {
 
     String identifier();
 
-    JSONObject data();
+    Object data();
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
@@ -15,7 +15,7 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 /**
  * Collects app metrics
  */
-public class AppMetrics implements Metrics {
+public class AppMetrics implements Metrics<JSONObject> {
 
     private final String appId;
     private final String appVersion;

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
@@ -48,7 +48,7 @@ public class AppMetrics implements Metrics {
         } catch (JSONException e) {
             MobileCore.getLogger().error("Error building JSON for App Metrics", e);
         }
-        return null;
+        return data;
     }
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.Metrics;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,12 +38,17 @@ public class AppMetrics implements Metrics {
      * @return Map of app info
      */
     @Override
-    public Map<String, String> data() {
-        Map<String, String> data = new HashMap<>();
-        data.put("appId", appId);
-        data.put("appVersion", appVersion);
-        data.put("sdkVersion", sdkVersion);
-        return data;
+    public JSONObject data() {
+        JSONObject data = new JSONObject();
+        try {
+            data.put("appId", appId);
+            data.put("appVersion", appVersion);
+            data.put("sdkVersion", sdkVersion);
+            return data;
+        } catch (JSONException e) {
+            MobileCore.getLogger().error("Error building JSON for App Metrics", e);
+        }
+        return null;
     }
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 /**
  * Collects device metrics
  */
-public class DeviceMetrics implements Metrics {
+public class DeviceMetrics implements Metrics<JSONObject> {
 
     private final String platform;
     private final String platformVersion;

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
@@ -4,9 +4,10 @@ import android.content.Context;
 import android.os.Build;
 
 import org.aerogear.mobile.core.metrics.Metrics;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Collects device metrics
@@ -27,10 +28,14 @@ public class DeviceMetrics implements Metrics {
     }
 
     @Override
-    public Map<String, String> data() {
-        Map<String, String> data = new HashMap<>();
-        data.put("platform", platform);
-        data.put("platformVersion", platformVersion);
+    public JSONObject data() {
+        JSONObject data = new JSONObject();
+        try {
+            data.put("platform", platform);
+            data.put("platformVersion", platformVersion);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
         return data;
     }
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
@@ -3,6 +3,7 @@ package org.aerogear.mobile.core.metrics.impl;
 import android.content.Context;
 import android.os.Build;
 
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -29,12 +30,12 @@ public class DeviceMetrics implements Metrics {
 
     @Override
     public JSONObject data() {
-        JSONObject data = new JSONObject();
+        final JSONObject data = new JSONObject();
         try {
             data.put("platform", platform);
             data.put("platformVersion", platformVersion);
         } catch (JSONException e) {
-            e.printStackTrace();
+            MobileCore.getLogger().error("Error building JSON for Device Metrics", e);
         }
         return data;
     }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -42,7 +42,7 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
 
             final JSONObject data = new JSONObject();
             for (final Metrics m : metrics) {
-                data.put(m.identifier(), new JSONObject(m.data()));
+                data.put(m.identifier(), m.data());
             }
 
             json.put("data", data);

--- a/core/src/test/java/org/aerogear/mobile/core/metrics/MetricsServiceTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/metrics/MetricsServiceTest.java
@@ -62,7 +62,7 @@ public class MetricsServiceTest {
         metricsService.publish(new DummyMetrics());
     }
 
-    public static class DummyMetrics implements Metrics {
+    public static class DummyMetrics implements Metrics<Map<String, String>> {
 
         @Override
         public String identifier() {

--- a/core/src/test/java/org/aerogear/mobile/core/metrics/impl/AppMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/metrics/impl/AppMetricsTest.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import android.support.test.filters.SmallTest;
 
 import org.aerogear.mobile.core.MobileCore;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,15 +35,15 @@ public class AppMetricsTest {
     }
 
     @Test
-    public void testData() {
+    public void testData() throws JSONException {
         Application context = RuntimeEnvironment.application;
 
         AppMetrics appMetrics = new AppMetrics(context);
-        Map<String, String> result = appMetrics.data();
+        JSONObject result = appMetrics.data();
 
-        assertNotNull(result.get("appId"));
-        assertNotNull(result.get("appVersion"));
-        assertNotNull(result.get("sdkVersion"));
+        assertNotNull(result.getString("appId"));
+        assertNotNull(result.getString("appVersion"));
+        assertNotNull(result.getString("sdkVersion"));
     }
 
 }

--- a/core/src/test/java/org/aerogear/mobile/core/metrics/impl/DeviceMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/metrics/impl/DeviceMetricsTest.java
@@ -3,6 +3,8 @@ package org.aerogear.mobile.core.metrics.impl;
 import android.app.Application;
 import android.support.test.filters.SmallTest;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -26,14 +28,14 @@ public class DeviceMetricsTest {
     }
 
     @Test
-    public void testData() {
+    public void testData() throws JSONException {
         Application context = RuntimeEnvironment.application;
 
         DeviceMetrics deviceMetrics = new DeviceMetrics(context);
-        Map<String, String> result = deviceMetrics.data();
+        JSONObject result = deviceMetrics.data();
 
-        assertNotNull(result.get("platform"));
-        assertNotNull(result.get("platformVersion"));
+        assertNotNull(result.getString("platform"));
+        assertNotNull(result.getString("platformVersion"));
     }
 
 }


### PR DESCRIPTION
## Motivation

<!-- The reason underlying the contents of the PR, can be a link to the originating JIRA -->

JIRA: https://issues.jboss.org/browse/AGDROID-771

## Description

<!-- The contents of the Pull Request, such as an overview of the changes implemented and impacted areas, additions, removals, etc. -->

Make both Sync and Async executors send a single metrics request upon finishing execution.
Update data being sent to match the server-side implementation at https://github.com/aerogear/aerogear-app-metrics/pull/33

## Progress

- [x] Add support for multiple results
- [x] Update call from sync executor
- [x] Update call from async executor
- [x] Update unit tests
- [x] Add `type` field
- [x] Change syncing mechanism to `syncroninzed` keyword
- [x] Make metrics interface generic