### PR TITLE
Added metric publishing batching

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AbstractSecurityCheckExecutor.java
@@ -60,12 +60,25 @@ abstract class AbstractSecurityCheckExecutor<T extends AbstractSecurityCheckExec
     }
 
     /**
-     * Gets the metrics service.
+     * Gets the metric published. It never returns null: if no metric service is present, e NOOP publisher
+     * is returned.
      *
-     * @return {@link MetricsService}
+     * @return the metric service publisher
      */
-    protected MetricsService getMetricsService() {
-        return metricsService;
+    protected SecurityCheckExecutorListener getMetricServicePublisher() {
+        if (metricsService != null) {
+            return new SecurityCheckMetricPublisher(metricsService);
+        } else {
+            return new SecurityCheckExecutorListener() {
+                @Override
+                public void onExecuted(SecurityCheckResult result) {
+                }
+
+                @Override
+                public void onFinished() {
+                }
+            };
+        }
     }
 
     /**

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -98,10 +98,23 @@ public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<As
      * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
      * a {@link Map} of {@link Future} with the {@link SecurityCheckResult} of the check.
      *
+     * @return {@link Map}
+     */
+    public Map<String, Future<SecurityCheckResult>> execute() {
+        return execute(new SecurityCheckExecutorListener[0]);
+    }
+
+    /**
+     * Executes the checks asynchronously.
+     *
+     * Returns a {@link Map} containing the results of each executed test (a {@link Future}).
+     * The key of the map will be the output of {@link SecurityCheck#getName()}, while the value will be
+     * a {@link Map} of {@link Future} with the {@link SecurityCheckResult} of the check.
+     *
      * @param securityCheckExecutorListeners list of listeners that will receive events about checks execution
      * @return {@link Map}
      */
-    public Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
+    private Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
 
         final List<SecurityCheckExecutorListener> listeners =
             securityCheckExecutorListeners == null ? new ArrayList<>(1) : new ArrayList(Arrays.asList(securityCheckExecutorListeners));

--- a/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/AsyncSecurityCheckExecutor.java
@@ -103,22 +103,17 @@ public class AsyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<As
      */
     public Map<String, Future<SecurityCheckResult>> execute(SecurityCheckExecutorListener... securityCheckExecutorListeners) {
 
-        final List<SecurityCheckExecutorListener> listeners;
+        final List<SecurityCheckExecutorListener> listeners =
+            securityCheckExecutorListeners == null ? new ArrayList<>(1) : new ArrayList(Arrays.asList(securityCheckExecutorListeners));
         final Collection<SecurityCheck> checks = getChecks();
 
-        // Initializes listener list: the metric publisher will be added to passed in listeners
-        if (securityCheckExecutorListeners == null) {
-            listeners = new ArrayList<>(1);
-        } else {
-            listeners = new ArrayList(Arrays.asList(securityCheckExecutorListeners));
-        }
-
+        // Adds the metric publisher to the passed in listeners
         listeners.add(getMetricServicePublisher());
 
         final Map<String, Future<SecurityCheckResult>> res = new HashMap<>();
         final AtomicInteger count = new AtomicInteger(checks.size());
 
-        for (final SecurityCheck check : getChecks()) {
+        for (final SecurityCheck check : checks) {
             res.put(check.getName(), (executorService.submit(() -> {
                 final SecurityCheckResult result =  check.test(getContext());
 

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutorListener.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckExecutorListener.java
@@ -1,0 +1,20 @@
+package org.aerogear.mobile.security;
+
+import org.aerogear.mobile.security.SecurityCheckResult;
+
+/**
+ * Listener for events about check execution.
+ */
+public interface SecurityCheckExecutorListener {
+
+    /**
+     * Called after each check is executed
+     * @param result the result of the check
+     */
+    void onExecuted(SecurityCheckResult result);
+
+    /**
+     * Called when all submitted checks has been executed.
+     */
+    void onFinished();
+}

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -1,0 +1,36 @@
+package org.aerogear.mobile.security;
+
+
+import org.aerogear.mobile.core.metrics.MetricsService;
+import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This object will manage the communication with the metric service, batching the results to be published.
+ */
+class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
+
+    private final MetricsService metricsService;
+    private final List<SecurityCheckResultMetric> metrics = new ArrayList<>();
+
+    /**
+     * Builds the object.
+     *
+     * @param metricsService metric service to be used to publish the metrics
+     */
+    SecurityCheckMetricPublisher(final MetricsService metricsService) {
+        this.metricsService = metricsService;
+    }
+
+    @Override
+    public synchronized void onExecuted(SecurityCheckResult result) {
+        metrics.add(new SecurityCheckResultMetric(result));
+    }
+
+    @Override
+    public synchronized void onFinished() {
+        metricsService.publish(metrics.toArray(new SecurityCheckResultMetric[metrics.size()]));
+    }
+}

--- a/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SyncSecurityCheckExecutor.java
@@ -70,26 +70,17 @@ public class SyncSecurityCheckExecutor extends AbstractSecurityCheckExecutor<Syn
     public Map<String, SecurityCheckResult> execute() {
         final Map<String, SecurityCheckResult> results = new HashMap<>();
 
+        final SecurityCheckExecutorListener metricServicePublisher = getMetricServicePublisher();
+
         for (SecurityCheck check : getChecks()) {
             SecurityCheckResult result = check.test(getContext());
             results.put(check.getName(), result);
-            publishResultMetrics(result);
+
+            metricServicePublisher.onExecuted(result);
         }
+
+        metricServicePublisher.onFinished();
 
         return results;
-    }
-
-    /**
-     * Publish each result provided as an {@link SecurityCheckResultMetric}.
-     *
-     * @param result {@link SecurityCheckResult} to be published
-     * @throws IllegalArgumentException if result is null
-     */
-    private void publishResultMetrics(@NonNull SecurityCheckResult result) {
-        MetricsService metricsService = getMetricsService();
-
-        if (metricsService != null) {
-            metricsService.publish(new SecurityCheckResultMetric(nonNull(result, "result")));
-        }
     }
 }


### PR DESCRIPTION
Added event listener

## Motivation

Implementation proposal for batch metric publishing that avoids polluting the code with logic to batch the metrics.

## Description

We currently want to avoid modifying the metric service to add batch received metrics, so we have to add some batching logic to the async/sync security check executors.

This implementation adds the ability to pass `listeners` to the execute method, so that events can be received as the checks are executed (`onExecuted` and `onFinished`).
A `SecurityCheckMetricPublisher` class implementing the listener interface is provided to batch the metrics and publish them when `onFinished` is received.

With this approach we have two benefits:
1. The code to batch the metrics is outside the executor class
2. We provide the user another useful interface

## Improvements

We could change the publisher so that after a number of metrics have been received, the metrics get published anyway, even before `onFinish` is called.
