### PR TITLE
Give users first and last names

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/user/UserPrincipal.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/user/UserPrincipal.java
@@ -32,7 +32,28 @@ public interface UserPrincipal extends Serializable {
      * 
      * @return the username
      */
+    String getUsername();
+
+    /**
+     * Returns the full name of the user. Both first and last name.
+     * 
+     * @return users full name
+     */
     String getName();
+
+    /**
+     * Returns the first name of the user.
+     * 
+     * @return users first name.
+     */
+    String getFirstName();
+
+    /**
+     * Returns the last name of the user.
+     * 
+     * @return users last name.
+     */
+    String getLastName();
 
     /**
      * Returns the email

--- a/auth/src/main/java/org/aerogear/mobile/auth/user/UserPrincipalImpl.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/user/UserPrincipalImpl.java
@@ -17,6 +17,16 @@ public class UserPrincipalImpl implements UserPrincipal {
     private final String username;
 
     /**
+     * The first name of the principal.
+     */
+    private final String firstName;
+
+    /**
+     * The last name of the principal.
+     */
+    private final String lastName;
+
+    /**
      * The email associated with this user
      */
     private final String email;
@@ -45,6 +55,8 @@ public class UserPrincipalImpl implements UserPrincipal {
      * Builds a new UserPrincipalImpl object
      *
      * @param username the username of the authenticated user
+     * @param firstName the first name of the authenticated user
+     * @param lastName the last name of the authenticated user
      * @param email the email of the authenticated user
      * @param roles roles assigned to the user
      * @param identityToken the identity token
@@ -52,10 +64,13 @@ public class UserPrincipalImpl implements UserPrincipal {
      * @param refreshToken the refresh token
      *
      */
-    protected UserPrincipalImpl(final String username, final String email,
-                    final Set<UserRole> roles, final String identityToken, final String accessToken,
+    protected UserPrincipalImpl(final String username, final String firstName,
+                    final String lastName, final String email, final Set<UserRole> roles,
+                    final String identityToken, final String accessToken,
                     final String refreshToken) {
         this.username = nonEmpty(username, "username");
+        this.firstName = firstName;
+        this.lastName = lastName;
         this.email = email;
         this.roles = new HashSet(roles);
         this.identityToken = identityToken;
@@ -73,8 +88,20 @@ public class UserPrincipalImpl implements UserPrincipal {
         protected String idToken;
         protected String accessToken;
         protected String refreshToken;
+        protected String firstName;
+        protected String lastName;
 
         protected Builder() {}
+
+        public Builder withFirstName(final String firstName) {
+            this.firstName = firstName;
+            return this;
+        }
+
+        public Builder withLastName(final String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
 
         public Builder withUsername(final String username) {
             this.username = nonEmpty(username, "username");
@@ -110,14 +137,14 @@ public class UserPrincipalImpl implements UserPrincipal {
         }
 
         public UserPrincipalImpl build() {
-            return new UserPrincipalImpl(this.username, this.email, this.roles, this.idToken,
-                            this.accessToken, this.refreshToken);
+            return new UserPrincipalImpl(this.username, this.firstName, this.lastName, this.email,
+                            this.roles, this.idToken, this.accessToken, this.refreshToken);
         }
     }
 
     /**
      * Checks if the user has the specified Client role.
-     * 
+     *
      * @param role role to be checked
      * @param clientId clientID related to role
      * @return <code>true</code> or <code>false</code>
@@ -131,7 +158,7 @@ public class UserPrincipalImpl implements UserPrincipal {
 
     /**
      * Checks if the user has the specified Realm role.
-     * 
+     *
      * @param role role to be checked
      * @return <code>true</code> or <code>false</code>
      */
@@ -143,8 +170,23 @@ public class UserPrincipalImpl implements UserPrincipal {
     }
 
     @Override
-    public String getName() {
+    public String getUsername() {
         return username;
+    }
+
+    @Override
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @Override
+    public String getLastName() {
+        return lastName;
+    }
+
+    @Override
+    public String getName() {
+        return firstName + " " + lastName;
     }
 
     /**
@@ -182,13 +224,14 @@ public class UserPrincipalImpl implements UserPrincipal {
         }
         sb.append("]");
 
-        return "UserPrincipalImpl{" + "username='" + username + '\'' + ", email='" + email + '\''
+        return "UserPrincipalImpl{" + "username='" + username + '\'' + ", firstName=" + firstName
+                        + '\'' + ", lastName=" + lastName + '\'' + ", email='" + email + '\''
                         + ", roles=" + sb.toString() + '}';
     }
 
     /**
      * Returns the identity token. It is used during logout.
-     * 
+     *
      * @return the identity token
      */
     @Override
@@ -199,7 +242,7 @@ public class UserPrincipalImpl implements UserPrincipal {
     /**
      * Returns the access token for the current logged user. This token can be added to HTTP
      * requests as the "Authorization: Bearer" header.
-     * 
+     *
      * @return the access token
      */
     @Override
@@ -209,7 +252,7 @@ public class UserPrincipalImpl implements UserPrincipal {
 
     /**
      * Returns the refresh token.
-     * 
+     *
      * @return the refresh token
      */
     @Override

--- a/auth/src/main/java/org/aerogear/mobile/auth/utils/UserIdentityParser.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/utils/UserIdentityParser.java
@@ -24,6 +24,8 @@ public class UserIdentityParser {
     private static final String REALM = "realm_access";
     private static final String CLIENT = "resource_access";
     private static final String ROLES = "roles";
+    private static final String FIRST_NAME = "given_name";
+    private static final String LAST_NAME = "family_name";
     private static final String RESOURCE = "resource";
     private static final String COMMA = ",";
 
@@ -49,6 +51,36 @@ public class UserIdentityParser {
             decodeUserIdentity();
         }
         this.keycloakConfiguration = nonNull(keycloakConfiguration, "keycloakConfiguration");
+    }
+
+    /**
+     * Parse the users first name from the {@link #userIdentity users identity}
+     *
+     * @return user's first name
+     * @throws JSONException if the {@link #FIRST_NAME} property cannot be retrieved from the user
+     *         identity.
+     */
+    public String parseFirstName() throws JSONException {
+        String firstName = "";
+        if (userIdentity != null && userIdentity.has(FIRST_NAME)) {
+            firstName = userIdentity.getString(FIRST_NAME);
+        }
+        return firstName;
+    }
+
+    /**
+     * Parse the users last name from the {@link #userIdentity users identity}
+     *
+     * @return user's last name
+     * @throws JSONException if the {@link #LAST_NAME} property cannot be retrieved from the user
+     *         identity.
+     */
+    public String parseLastName() throws JSONException {
+        String lastName = "";
+        if (userIdentity != null && userIdentity.has(LAST_NAME)) {
+            lastName = userIdentity.getString(LAST_NAME);
+        }
+        return lastName;
     }
 
     /**
@@ -108,8 +140,9 @@ public class UserIdentityParser {
 
     public UserPrincipalImpl parseUser() throws AuthenticationException {
         try {
-            return UserPrincipalImpl.newUser().withEmail(parseEmail()).withUsername(parseUsername())
-                            .withRoles(parseRoles())
+            return UserPrincipalImpl.newUser().withEmail(parseEmail())
+                            .withFirstName(parseFirstName()).withLastName(parseLastName())
+                            .withUsername(parseUsername()).withRoles(parseRoles())
                             .withIdentityToken(credential.getIdentityToken())
                             .withAccessToken(credential.getAccessToken())
                             .withRefreshToken(credential.getRefreshToken()).build();

--- a/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
@@ -236,7 +236,10 @@ public class OIDCAuthenticatorImplTest {
         authenticator.authenticate(opts, new Callback<UserPrincipal>() {
             @Override
             public void onSuccess(UserPrincipal userPrincipal) {
-                Assert.assertEquals("user1", userPrincipal.getName());
+                Assert.assertEquals("User 1", userPrincipal.getName());
+                Assert.assertEquals("user1", userPrincipal.getUsername());
+                Assert.assertEquals("User", userPrincipal.getFirstName());
+                Assert.assertEquals("1", userPrincipal.getLastName());
                 Assert.assertEquals("user1@feedhenry.org", userPrincipal.getEmail());
             }
 

--- a/docs/getting-started/auth.adoc
+++ b/docs/getting-started/auth.adoc
@@ -92,8 +92,12 @@ no user authenticated. So it can be used to check whether to start the authentic
 UserPrincipal currentUser = authService.currentUser();
 
 if (currentUser != null) {
-    // User is authenticated, get the users name
-    String userName = currentUser.getName();
+    // User is authenticated, get the users username
+    String userName = currentUser.getUsername();
+    // Get the users first name
+    String firstName = currentUser.getFirstName();
+    // Get the users last name
+    String lastName = currentUser.getLastName();
     // Get the users email address
     String userEmail = currentUser.getEmail();
     // Get the access token of the authenticated user


### PR DESCRIPTION
## Motivation

We only currently expose the users username. This is not the same as a full name, it's a unique identifier that could be anything. We should also expose the first and last name of the user.

## Description

Updating the user principal to allow for a first name and a last name to be provided to it and retrieved from it. Update the example app to use `getUsername` instead of `getName`.

Resolves https://github.com/aerogear/aerogear-android-sdk/issues/89

## Progress

- [x] Implementation
- [x] Documentation
- [x] Unit tests
