### PR TITLE
fixed mobile-services.json (it was broken)

### DIFF
--- a/example/src/main/assets/mobile-services.json
+++ b/example/src/main/assets/mobile-services.json
@@ -21,7 +21,7 @@
         {
             "id": "metrics",
             "name": "metrics",
-            "url": "http://192.168.0.101:3000/metrics"
+            "url": "http://192.168.0.101:3000/metrics",
             "type": "metrics",
             "config": {
             }


### PR DESCRIPTION
## Motivation
Previous metrics PR broke default  mobile-services.json. It was breaking my E2E tests.