### PR TITLE
Remove link to metrics contributor guide

### DIFF
--- a/docs/getting-started/metrics.adoc
+++ b/docs/getting-started/metrics.adoc
@@ -32,6 +32,3 @@ The Client ID will be generated and stored on the device when the App is started
 - *Platform*: Hardcoded to `android`
 - *Platform Version*: The API level of the device
 
-=== Extending metrics
-
-See link:./metrics-development.adoc[Extending Metrics Guide] 


### PR DESCRIPTION
### Motivation

Remove contributor guide link from metrics user guide doc.

Same done on IOS: https://github.com/aerogear/aerogear-ios-sdk/pull/40