### PR TITLE
Improving GAV coordinates 

### DIFF
--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,3 +1,3 @@
 POM_NAME=AeroGear Android SDK
-POM_ARTIFACT_ID=auth
+POM_ARTIFACT_ID=android-auth
 POM_PACKAGING=aar

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,3 +1,3 @@
 POM_NAME=AeroGear Android SDK
-POM_ARTIFACT_ID=core
+POM_ARTIFACT_ID=android-core
 POM_PACKAGING=aar


### PR DESCRIPTION
## Motivation

the maven artifacts are not named very well:
* `org.aerogear:core` 
* `org.aerogear:auth`

this can mean anything.

Motivation to add some android context on the JARs...


## Description

updating the GAV for better names (tm)

## Progress

- [x] Done Task

