### PR TITLE
Add getting started video to auth SDK

### DIFF
--- a/docs/getting-started/auth.adoc
+++ b/docs/getting-started/auth.adoc
@@ -4,6 +4,8 @@ Mobile authentication SDK based on link:http://www.keycloak.org/[Keycloak] using
 
 Provides authentication features like access control and two factor authentication through Keycloak.
 
+image::https://img.youtube.com/vi/MGecRG11k6E/0.jpg[title="Demo Video (https://www.youtube.com/watch?v=MGecRG11k6E&feature=youtu.be)", link="https://www.youtube.com/watch?v=MGecRG11k6E&feature=youtu.be",caption=""]
+
 == Usage
 
 To use the Auth SDK you'll first need to:

--- a/docs/getting-started/getting-started.adoc
+++ b/docs/getting-started/getting-started.adoc
@@ -1,7 +1,6 @@
 == Getting Started with AeroGear Services Android SDK
 
 Following guide provides general information for starting with AeroGear Services SDK.
-If you looking for 
 
 == Prerequisites
 


### PR DESCRIPTION
## Motivation

Currently we do not link the video providing an end to end example
of using Keycloak in our documentation. This change adds the video
in the form of an image that once clicked will open YouTube.

The reason for not using the asciidoc video tag is because it does
not create the desired effect when rendered on GitHub.

This seems to be the best way to go about it if we want some visual
thing instead of just a link.

## Description
Add an image that links to the YouTube video.

## Progress

- [x] Add image with link
