### PR TITLE
Move auth Callback to the core module

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -22,6 +22,7 @@ import org.aerogear.mobile.auth.credentials.JwksManager;
 import org.aerogear.mobile.auth.credentials.OIDCCredentials;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.utils.UserIdentityParser;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.ServiceModule;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/AbstractAuthenticator.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/AbstractAuthenticator.java
@@ -4,8 +4,8 @@ import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
 import android.support.annotation.NonNull;
 
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.user.UserPrincipal;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 
 /**

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
@@ -13,7 +13,6 @@ import android.app.Activity;
 import android.content.Intent;
 
 import org.aerogear.mobile.auth.AuthStateManager;
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.authenticator.AbstractAuthenticator;
 import org.aerogear.mobile.auth.authenticator.AuthenticateOptions;
 import org.aerogear.mobile.auth.authenticator.AuthorizationServiceFactory;
@@ -25,6 +24,7 @@ import org.aerogear.mobile.auth.credentials.OIDCCredentials;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.user.UserPrincipalImpl;
 import org.aerogear.mobile.auth.utils.UserIdentityParser;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 import org.aerogear.mobile.core.http.HttpRequest;

--- a/auth/src/main/java/org/aerogear/mobile/auth/credentials/JwksManager.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/credentials/JwksManager.java
@@ -12,9 +12,9 @@ import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;
@@ -50,9 +50,9 @@ public class JwksManager {
      * cached JWKS found. It will trigger a request to fetch the JWKS in the background if there is
      * no cached key found, or {@link AuthServiceConfiguration#getMinTimeBetweenJwksRequests()} is
      * passed since the key set is requested last time.
-     * 
+     *
      * @param keyCloakConfig the configuration to use to load the JWKS object
-     * 
+     *
      * @return the cached JWKS, or null if it doesn't exist
      */
     public JsonWebKeySet load(final KeycloakConfiguration keyCloakConfig) {
@@ -78,7 +78,7 @@ public class JwksManager {
      * trigger if: 1. forceFetch is set to true, or 2.
      * {@link AuthServiceConfiguration#getMinTimeBetweenJwksRequests()} is passed since the key set
      * is requested last time.
-     * 
+     *
      * @param keycloakConfiguration the configuration of the keycloak server
      * @param forceFetch if set to true, the request will be trigger immediately.
      * @return whether the keys has been fetched or not.
@@ -95,7 +95,7 @@ public class JwksManager {
 
     /**
      * Call the remote endpoint to load the JWKS and save it locally.
-     * 
+     *
      * @param keycloakConfiguration the configuration of the keycloak server
      * @param callback the callback function to be invoked when the request is completed. Can be
      *        null.
@@ -139,7 +139,7 @@ public class JwksManager {
 
     /**
      * Check when the JWKS was requested last time and determine if a request should be sent again.
-     * 
+     *
      * @param keyCloakConfig the configuration of the Keycloak server
      * @return true if the request should be triggered
      */
@@ -159,7 +159,7 @@ public class JwksManager {
 
     /**
      * Save the JWKS content for the given name space locally using SharedPreferences.
-     * 
+     *
      * @param namespace the namespace associated with the JWKS
      * @param jwksContent the content of the JWKS
      */
@@ -177,7 +177,7 @@ public class JwksManager {
 
     /**
      * Build the entry name for the JWKS content
-     * 
+     *
      * @param namespace the namespace associated with the JWKS
      * @return the full entry name
      */
@@ -187,7 +187,7 @@ public class JwksManager {
 
     /**
      * Build the entry name for the last requested date for the JWKS content
-     * 
+     *
      * @param namespace the namespace associated with the JWKS
      * @return the full entry name
      */

--- a/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 
 import org.aerogear.mobile.auth.AuthStateManager;
 import org.aerogear.mobile.auth.AuthenticationException;
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.authenticator.oidc.OIDCAuthenticatorImpl;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
@@ -29,6 +28,7 @@ import org.aerogear.mobile.auth.credentials.JwksManager;
 import org.aerogear.mobile.auth.credentials.OIDCCredentials;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.user.UserPrincipalImpl;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 
 import junit.framework.Assert;

--- a/auth/src/test/java/org/aerogear/mobile/auth/credentials/JwksManagerTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/credentials/JwksManagerTest.java
@@ -24,9 +24,9 @@ import org.robolectric.RobolectricTestRunner;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;

--- a/core/src/main/java/org/aerogear/mobile/core/Callback.java
+++ b/core/src/main/java/org/aerogear/mobile/core/Callback.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.auth;
+package org.aerogear.mobile.core;
 
 public interface Callback<T extends Object> {
     default void onSuccess() {}

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthDetailsFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthDetailsFragment.java
@@ -12,9 +12,9 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import org.aerogear.mobile.auth.AuthService;
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.auth.user.UserRole;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.example.R;
 
 import butterknife.BindView;

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -5,9 +5,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.aerogear.mobile.auth.AuthService;
-import org.aerogear.mobile.auth.Callback;
 import org.aerogear.mobile.auth.authenticator.DefaultAuthenticateOptions;
 import org.aerogear.mobile.auth.user.UserPrincipal;
+import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.example.R;
 
 import butterknife.BindView;


### PR DESCRIPTION
There is a Callback class in the Auth module and it should be reused (for now) in the other modules, so it should be in Core instead of in Auth module.