### PR TITLE
Allow Custom Scopes to be Passed, Allow OAuth

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/AuthorizationServiceFactory.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/AuthorizationServiceFactory.java
@@ -22,8 +22,6 @@ import net.openid.appauth.browser.VersionedBrowserMatcher;
  */
 public class AuthorizationServiceFactory {
 
-    private final static String SCOPE_OPENID = "openid";
-
     private final Context appContext;
 
     /**
@@ -58,7 +56,7 @@ public class AuthorizationServiceFactory {
 
     /**
      * Builds a new AuthorizationServiceFactory
-     * 
+     *
      * @param appContext the application context
      */
     public AuthorizationServiceFactory(@NonNull final Context appContext) {
@@ -68,7 +66,7 @@ public class AuthorizationServiceFactory {
     /**
      * Creates and initializes a new {@link AuthorizationService} ready to be used for
      * authenticating with Keycloak.
-     * 
+     *
      * @param keycloakConfiguration configuration to be used to access keycloak
      * @param authServiceConfiguration the authentication singleThreadService configuration
      * @return a wrapper object containing all the `openid` object used to handle the OIDC
@@ -95,7 +93,8 @@ public class AuthorizationServiceFactory {
         AuthorizationService authService = new AuthorizationService(this.appContext, appAuthConfig);
         AuthorizationRequest authRequest = new AuthorizationRequest.Builder(authServiceConfig,
                         keycloakConfiguration.getClientId(), ResponseTypeValues.CODE,
-                        authServiceConfiguration.getRedirectUri()).setScopes(SCOPE_OPENID).build();
+                        authServiceConfiguration.getRedirectUri())
+                                        .setScopes(authServiceConfiguration.getScopes()).build();
 
         return new ServiceWrapper(authService, authState, authRequest);
     }

--- a/auth/src/main/java/org/aerogear/mobile/auth/configuration/AuthServiceConfiguration.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/configuration/AuthServiceConfiguration.java
@@ -10,9 +10,19 @@ import android.net.Uri;
 public class AuthServiceConfiguration {
 
     /**
+     * The default scope.
+     */
+    private final String SCOPE_OPENID;
+
+    /**
      * The redirect uri for the developers app.
      */
     private final Uri redirectUri;
+
+    /**
+     * The OIDC scopes to use in the auth request.
+     */
+    private final String scopes;
 
     /**
      * Specify the minimum time between requests to get the JWKS (Json web key set) in minutes. The
@@ -28,6 +38,8 @@ public class AuthServiceConfiguration {
     private AuthServiceConfiguration(final AuthConfigurationBuilder builder) {
         this.redirectUri = builder.redirectUri;
         this.minTimeBetweenJwksRequests = builder.minTimeBetweenJwksRequests;
+        this.scopes = builder.scopes;
+        this.SCOPE_OPENID = builder.SCOPE_OPENID;
     }
 
     /**
@@ -36,17 +48,30 @@ public class AuthServiceConfiguration {
     public static class AuthConfigurationBuilder {
         private Uri redirectUri;
         private int minTimeBetweenJwksRequests = 24 * 60;
+        private String scopes;
+        private final String SCOPE_OPENID = "openid";
 
         public AuthConfigurationBuilder() {}
 
         /**
          * Allow specify the value of the redirect uri
-         * 
+         *
          * @param redirectUri a new redirectUri value
          * @return the builder instance
          */
         public AuthConfigurationBuilder withRedirectUri(final String redirectUri) {
             this.redirectUri = Uri.parse(nonNull(redirectUri, "redirectUri"));
+            return this;
+        }
+
+        /**
+         * Allow specifying the OIDC scopes of the auth request
+         *
+         * @param scopes the OIDC scopes
+         * @return the builder instance
+         */
+        public AuthConfigurationBuilder withScopes(final String scopes) {
+            this.scopes = scopes;
             return this;
         }
 
@@ -66,6 +91,18 @@ public class AuthServiceConfiguration {
      */
     public Uri getRedirectUri() {
         return redirectUri;
+    }
+
+    /**
+     * @return the OIDC scopes for the auth request. If no scopes are defined, the default 'openid'
+     *         scope will be sent.
+     */
+    public String getScopes() {
+        if (scopes != null) {
+            return scopes;
+        } else {
+            return SCOPE_OPENID;
+        }
     }
 
     /**

--- a/docs/getting-started/auth.adoc
+++ b/docs/getting-started/auth.adoc
@@ -80,6 +80,15 @@ AuthServiceConfiguration authServiceConfig = new AuthServiceConfiguration.AuthCo
 authService.init(context, authServiceConfig);
 ----
 
+==== Defining Custom Scopes
+Optionally, scopes can be defined for the auth request using a space as the delimiter as per https://tools.ietf.org/html/rfc6749#section-3.3[RFC-6749].
+By default, the `"openid"` scope is sent if no scopes are defined.
+[source,java]
+----
+// default is 'openid' when not defined
+.withScopes("openid offline_access")
+----
+
 If `AuthService#init` is not invoked then an `IllegalStateException` will be thrown when using the
 service.
 


### PR DESCRIPTION
## Motivation
Detail in https://github.com/aerogear/aerogear-android-sdk/issues/154

## Description
Allow custom scopes to be passed in the auth request. Currently this is hardcoded to `openid` by default. We should let the developer decide what scopes they want, and fallback to `openid` if they don't define ones.

## Progress

- [x] Allow custom scopes to be set in the builder.
