### PR TITLE
Removed Unnecessary Direct Access Grant Step

### DIFF
--- a/docs/getting-started/auth-single-sign-on.adoc
+++ b/docs/getting-started/auth-single-sign-on.adoc
@@ -22,7 +22,6 @@ It is not required to setup two or more Keycloak clients to achieve SSO across a
 .. The *openid-connect* option should be selected in the *Client Protocol* drop down box.
 .. For this example, the *public* option can be selected in the *Access Type* drop down box.
 .. *Standard Flow Enabled* should be set to *ON*.
-.. *Direct Access Grants Enabled* should be set to *ON*.
 .. *Valid Redirect URIs* should contain the redirect URL that has been specified in your *Email App Android Project*.  See the last point under the link:auth.adoc[Usage] section of the Auth SDK getting started guide.
 
 . If you'd like to create a new client for the *Keycloak Email Client* then follow this Keycloak guide - link:http://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients[Keycloak OIDC Clients] and ensure your client has the configuration specified in step 1.i-vii.


### PR DESCRIPTION
## Motivation
The Direct Access Grant should not be enabled. SSO uses the Standard/Auth Code flow.
