### PR TITLE
Add metrics integration test to Android SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}
       - run:
           name: Run Tests
-          command: ./gradlew lint testDebug spotlessCheck
+          command: ./gradlew lint testDebug --tests *.UnitTestSuite spotlessCheck
       - run:
           name: Generate Maven Artifacts
           command: ./gradlew install

--- a/auth/src/test/java/org/aerogear/mobile/auth/UnitTestSuite.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/UnitTestSuite.java
@@ -1,0 +1,22 @@
+package org.aerogear.mobile.auth;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import org.aerogear.mobile.auth.authenticator.OIDCAuthenticateOptionsTest;
+import org.aerogear.mobile.auth.authenticator.OIDCAuthenticatorImplTest;
+import org.aerogear.mobile.auth.credentials.JwksManagerTest;
+import org.aerogear.mobile.auth.credentials.OIDCCredentialsTest;
+import org.aerogear.mobile.auth.user.UserPrincipalImplTest;
+import org.aerogear.mobile.auth.utils.UserIdentityParserTest;
+
+/**
+ * Suite containing all unit tests in auth
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({OIDCAuthenticateOptionsTest.class, OIDCAuthenticatorImplTest.class,
+                JwksManagerTest.class, OIDCCredentialsTest.class, UserPrincipalImplTest.class,
+                UserIdentityParserTest.class, AuthServiceTest.class, AuthStateManagerTest.class})
+public class UnitTestSuite {
+
+}

--- a/auth/src/test/java/org/aerogear/mobile/security/UnitTestSuite.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/UnitTestSuite.java
@@ -1,0 +1,26 @@
+package org.aerogear.mobile.security;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import org.aerogear.mobile.security.checks.AllowBackupFlagCheckTest;
+import org.aerogear.mobile.security.checks.DebuggerCheckTest;
+import org.aerogear.mobile.security.checks.DeveloperModeCheckTest;
+import org.aerogear.mobile.security.checks.EmulatorCheckTest;
+import org.aerogear.mobile.security.checks.EncryptionCheckTest;
+import org.aerogear.mobile.security.checks.RootedCheckTest;
+import org.aerogear.mobile.security.checks.ScreenLockCheckTest;
+import org.aerogear.mobile.security.impl.SecurityCheckResultTest;
+import org.aerogear.mobile.security.metrics.SecurityCheckResultMetricTest;
+
+/**
+ * Suite containing all unit tests in security
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({AllowBackupFlagCheckTest.class, DebuggerCheckTest.class,
+                DeveloperModeCheckTest.class, EmulatorCheckTest.class, EncryptionCheckTest.class,
+                RootedCheckTest.class, ScreenLockCheckTest.class, SecurityCheckResultTest.class,
+                SecurityCheckResultMetricTest.class, SecurityCheckExecutorTest.class})
+public class UnitTestSuite {
+
+}

--- a/core/src/debug/assets/integration-test-mobile-services.json
+++ b/core/src/debug/assets/integration-test-mobile-services.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "clusterName": "192.168.64.74:8443",
+    "namespace": "myproject",
+    "clientId": "example_client_id",
+    "services": [
+        {
+            "id": "metrics",
+            "name": "metrics",
+            "type": "metrics",
+            "url": "https://do.not.exist",
+            "config": {}
+        }
+    ]
+}

--- a/core/src/test/java/org/aerogear/mobile/core/IntegrationTestSuite.java
+++ b/core/src/test/java/org/aerogear/mobile/core/IntegrationTestSuite.java
@@ -1,0 +1,15 @@
+package org.aerogear.mobile.core;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import org.aerogear.mobile.core.integration.MetricsServiceIntegrationTest;
+
+/**
+ * Suite containing all integration tests in core
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({MetricsServiceIntegrationTest.class})
+public class IntegrationTestSuite {
+
+}

--- a/core/src/test/java/org/aerogear/mobile/core/UnitTestSuite.java
+++ b/core/src/test/java/org/aerogear/mobile/core/UnitTestSuite.java
@@ -1,0 +1,25 @@
+package org.aerogear.mobile.core;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import org.aerogear.mobile.core.unit.MobileCoreTest;
+import org.aerogear.mobile.core.unit.configuration.MobileCoreParserTest;
+import org.aerogear.mobile.core.unit.configuration.ServiceConfigurationTest;
+import org.aerogear.mobile.core.unit.http.OkHttpServiceModuleTest;
+import org.aerogear.mobile.core.unit.metrics.MetricsServiceTest;
+import org.aerogear.mobile.core.unit.metrics.impl.AppMetricsTest;
+import org.aerogear.mobile.core.unit.metrics.impl.DeviceMetricsTest;
+import org.aerogear.mobile.core.unit.utils.SanityCheckTest;
+
+/**
+ * Suite containing all unit tests in core
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({MobileCoreTest.class, MobileCoreParserTest.class,
+                ServiceConfigurationTest.class, OkHttpServiceModuleTest.class,
+                MetricsServiceTest.class, AppMetricsTest.class, DeviceMetricsTest.class,
+                SanityCheckTest.class})
+public class UnitTestSuite {
+
+}

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -1,8 +1,10 @@
 package org.aerogear.mobile.core.integration;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +36,8 @@ public class MetricsServiceIntegrationTest {
 
         MobileCore mobileCore = MobileCore.init(RuntimeEnvironment.application, options);
         metricsService = mobileCore.getInstance(MetricsService.class);
+
+        error = null;
     }
 
     @Test
@@ -54,11 +58,9 @@ public class MetricsServiceIntegrationTest {
         };
 
         metricsService.sendAppAndDeviceMetrics(testCallback);
-        latch.await();
+        latch.await(10, TimeUnit.SECONDS);
 
-        if (error != null) {
-            fail(error.getMessage());
-        }
+        assertNull(error);
     }
 
     @Test
@@ -81,11 +83,9 @@ public class MetricsServiceIntegrationTest {
         };
 
         metricsService.publish(new Metrics[] {metrics}, testCallback);
-        latch.await();
+        latch.await(10, TimeUnit.SECONDS);
 
-        if (error != null) {
-            fail(error.getMessage());
-        }
+        assertNull(error);
     }
 
 }

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.aerogear.mobile.core.integration;
 
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -5,8 +5,9 @@ import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(JUnit4.class)
 public class MetricsServiceIntegrationTest {
 
     @Before

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -1,0 +1,22 @@
+package org.aerogear.mobile.core.integration;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PowerMockRunner.class)
+public class MetricsServiceIntegrationTest {
+
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    @Test
+    public void testSendMetricsShouldReturnNoError() throws Exception {
+        fail("Not yet implemented");
+    }
+
+}

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -1,23 +1,50 @@
 package org.aerogear.mobile.core.integration;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.robolectric.RuntimeEnvironment;
+
+import org.aerogear.mobile.core.Callback;
+import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
+import org.aerogear.mobile.core.metrics.MetricsService;
 
 @RunWith(JUnit4.class)
 public class MetricsServiceIntegrationTest {
 
+    MobileCore mobileCore;
+    MetricsService metricsService;
+
     @Before
     public void setUp() throws Exception {
-
+        mobileCore = MobileCore.init(RuntimeEnvironment.application);
+        metricsService = new MetricsService();
     }
 
     @Test
     public void testSendMetricsShouldReturnNoError() throws Exception {
-        fail("Not yet implemented");
+        ServiceConfiguration serviceConfiguration =
+                        new ServiceConfiguration.Builder().setUrl("TODO put integration server URL").build();
+        metricsService.configure(mobileCore, serviceConfiguration);
+
+        final Callback testCallback = new Callback() {
+            @Override
+            public void onSuccess() {
+                assertTrue(true);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                fail("Should not throw an error: " + error.getMessage());
+            }
+        };
+
+        metricsService.sendAppAndDeviceMetrics(testCallback);
     }
 
 }

--- a/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core;
+package org.aerogear.mobile.core.unit;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
@@ -14,6 +14,8 @@ import org.robolectric.RuntimeEnvironment;
 import android.app.Application;
 import android.support.test.filters.SmallTest;
 
+import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.ServiceModule;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 import org.aerogear.mobile.core.exception.ConfigurationNotFoundException;
 import org.aerogear.mobile.core.exception.InitializationException;

--- a/core/src/test/java/org/aerogear/mobile/core/unit/configuration/MobileCoreParserTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/configuration/MobileCoreParserTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.configuration;
+package org.aerogear.mobile.core.unit.configuration;
 
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.fail;
@@ -16,6 +16,9 @@ import org.robolectric.RuntimeEnvironment;
 
 import android.app.Application;
 import android.support.test.filters.SmallTest;
+
+import org.aerogear.mobile.core.configuration.MobileCoreJsonParser;
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 
 @RunWith(RobolectricTestRunner.class)
 @SmallTest

--- a/core/src/test/java/org/aerogear/mobile/core/unit/configuration/ServiceConfigurationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/configuration/ServiceConfigurationTest.java
@@ -1,9 +1,11 @@
-package org.aerogear.mobile.core.configuration;
+package org.aerogear.mobile.core.unit.configuration;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 
 @RunWith(RobolectricTestRunner.class)
 public class ServiceConfigurationTest {

--- a/core/src/test/java/org/aerogear/mobile/core/unit/http/OkHttpServiceModuleTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/http/OkHttpServiceModuleTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.http;
+package org.aerogear.mobile.core.unit.http;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
@@ -12,6 +12,11 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import android.support.test.filters.SmallTest;
+
+import org.aerogear.mobile.core.http.HttpRequest;
+import org.aerogear.mobile.core.http.HttpResponse;
+import org.aerogear.mobile.core.http.HttpServiceModule;
+import org.aerogear.mobile.core.http.OkHttpServiceModule;
 
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.metrics;
+package org.aerogear.mobile.core.unit.metrics;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -18,6 +18,8 @@ import android.support.test.filters.SmallTest;
 import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
+import org.aerogear.mobile.core.metrics.Metrics;
+import org.aerogear.mobile.core.metrics.MetricsService;
 import org.aerogear.mobile.core.metrics.publisher.LoggerMetricsPublisher;
 import org.aerogear.mobile.core.metrics.publisher.NetworkMetricsPublisher;
 

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/AppMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/AppMetricsTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.metrics.impl;
+package org.aerogear.mobile.core.unit.metrics.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -15,8 +15,10 @@ import android.app.Application;
 import android.support.test.filters.SmallTest;
 
 import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.metrics.impl.AppMetrics;
 
 @RunWith(RobolectricTestRunner.class)
+
 @SmallTest
 public class AppMetricsTest {
 

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/DeviceMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/DeviceMetricsTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.metrics.impl;
+package org.aerogear.mobile.core.unit.metrics.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -12,6 +12,8 @@ import org.robolectric.RuntimeEnvironment;
 
 import android.app.Application;
 import android.support.test.filters.SmallTest;
+
+import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
 
 @RunWith(RobolectricTestRunner.class)
 @SmallTest

--- a/core/src/test/java/org/aerogear/mobile/core/unit/utils/SanityCheckTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/utils/SanityCheckTest.java
@@ -1,4 +1,4 @@
-package org.aerogear.mobile.core.utils;
+package org.aerogear.mobile.core.unit.utils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -6,6 +6,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import android.support.test.filters.SmallTest;
+
+import org.aerogear.mobile.core.utils.SanityCheck;
 
 @RunWith(RobolectricTestRunner.class)
 @SmallTest


### PR DESCRIPTION
## Motivation

To add integration tests between Android SDK and App Metrics service to our current suite. 

JIRA: https://issues.jboss.org/browse/AEROGEAR-2189

## Description

This PR includes a rather major change test-wise:

Two separate test suites have been created: `UnitTestSuite` holds all unit tests and is the one to be run during PRs and local development, whereas `IntegrationTestSuite` holds this integration test and is to be run only in special occasions in Jenkins. In order to run a specific test suite, run:
```
# Integration tests
./gradlew :core:testDebug --tests *.IntegrationTestSuite

# Unit tests
./gradlew testDebug --tests UnitTestSuite
```

## Progress

- [x] Done

## Additional Notes and Verification

At the moment there aren't any integration tests in `auth`, so that the module has to be filtered as well: `:core:testDebug`.

This commands are only necessary when running from the console, with Android Studio it works like always.

Verification steps of the test suite changes:
1. Run the given commands and verify there are no unexpected errors.
```
# It should fail
./gradlew :core:testDebug --tests *.IntegrationTestSuite
# It should pass
./gradlew testDebug --tests *.UnitTestSuite
```
Verification integration test:
WIP: https://github.com/psturc/aerogear-android-sdk/blob/a35ff25cc2886277a476472ab87ea9818298df36/Jenkinsfile

