### PR TITLE
Auto init

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -32,7 +32,7 @@ import org.aerogear.mobile.core.logging.Logger;
  * Entry point for authenticating users.
  */
 public class AuthService implements ServiceModule {
-    private final static Logger LOG = MobileCore.getLogger();
+    private final static Logger LOG = MobileCore.getInstance().getLogger();
     private final static String TAG = "AuthService";
 
     private ServiceConfiguration serviceConfiguration;

--- a/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/authenticator/oidc/OIDCAuthenticatorImpl.java
@@ -197,12 +197,13 @@ public class OIDCAuthenticatorImpl extends AbstractAuthenticator {
                 // Non HTTP 200 or 302 Status Code Returned
                 Exception error = httpResponse.getError() != null ? httpResponse.getError()
                                 : new Exception("Non HTTP 200 or 302 Status Code.");
-                MobileCore.getLogger().error(
+                MobileCore.getInstance().getLogger().error(
                                 "Error Performing a Logout on the Remote OIDC Server: ", error);
                 logoutCallback.onError(error);
             }
         }).onError(() -> {
-            MobileCore.getLogger().error("Error Performing a Logout on the Remote OIDC Server: ",
+            MobileCore.getInstance().getLogger().error(
+                            "Error Performing a Logout on the Remote OIDC Server: ",
                             httpResponse.getError());
             logoutCallback.onError(httpResponse.getError());
         });

--- a/auth/src/main/java/org/aerogear/mobile/auth/credentials/JwksManager.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/credentials/JwksManager.java
@@ -26,7 +26,7 @@ import org.aerogear.mobile.core.logging.Logger;
  */
 public class JwksManager {
 
-    private static final Logger logger = MobileCore.getLogger();
+    private static final Logger logger = MobileCore.getInstance().getLogger();
     private static final int MILLISECONDS_PER_MINUTE = 60 * 1000;
     private static final String STORE_NAME = "org.aerogear.mobile.auth.JwksStore";
     private static final String ENTRY_SUFFIX_FOR_KEY_CONTENT = "jwks_content";

--- a/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/metrics/SecurityCheckResultMetric.java
@@ -20,7 +20,7 @@ import org.aerogear.mobile.security.SecurityCheckResult;
 public class SecurityCheckResultMetric implements Metrics<JSONArray> {
 
     private final JSONArray data;
-    private final Logger LOG = MobileCore.getLogger();
+    private final Logger LOG = MobileCore.getInstance().getLogger();
     private final String TAG = "SecurityCheckResultMetric";
 
     public static final String IDENTIFIER = "security";

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,2 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.aerogear.android.core" />
+    package="org.aerogear.android.core">
+
+    <application>
+        <provider
+            android:name="org.aerogear.mobile.core.bootstrap.AeroGearBootstrap"
+            android:authorities="${applicationId}.AeroGearBootstrap"
+            android:exported="false" />
+    </application>
+</manifest>
+

--- a/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
+++ b/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
@@ -110,12 +110,12 @@ public final class MobileCore {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends ServiceModule> T getInstance(final Class<T> serviceClass) {
-        return getInstance(serviceClass, null);
+    public <T extends ServiceModule> T getService(final Class<T> serviceClass) {
+        return getService(serviceClass, null);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends ServiceModule> T getInstance(final Class<T> serviceClass,
+    public <T extends ServiceModule> T getService(final Class<T> serviceClass,
                     final ServiceConfiguration serviceConfiguration)
                     throws InitializationException {
         nonNull(serviceClass, "serviceClass");

--- a/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
+++ b/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.json.JSONException;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
@@ -34,15 +35,17 @@ public final class MobileCore {
 
     public static final String DEFAULT_CONFIG_FILE_NAME = "mobile-services.json";
 
-    private static final String TAG = "AEROGEAR/CORE";
     private static final int DEFAULT_READ_TIMEOUT = 30;
     private static final int DEFAULT_CONNECT_TIMEOUT = 10;
     private static final int DEFAULT_WRITE_TIMEOUT = 10;
-    private static Logger logger = new LoggerAdapter();
-    private static String appVersion;
+
+    @SuppressLint("StaticFieldLeak")
+    private static MobileCore instance;
 
     private final Context context;
+    private final String appVersion;
     private final String configFileName;
+    private final Logger logger;
     private final HttpServiceModule httpLayer;
     private final Map<String, ServiceConfiguration> servicesConfig;
     private final Map<Class<? extends ServiceModule>, ServiceModule> services = new HashMap<>();
@@ -55,12 +58,11 @@ public final class MobileCore {
     private MobileCore(final Context context, final Options options)
                     throws InitializationException, IllegalStateException {
         this.context = nonNull(context, "context").getApplicationContext();
-        this.configFileName = nonNull(options, "options").configFileName;
 
-        // -- Allow to override the default logger
-        if (options.logger != null) {
-            logger = options.logger;
-        }
+        this.appVersion = getAppVersion(context);
+        this.configFileName = options.configFileName;
+        this.logger = options.logger;
+        this.httpLayer = options.httpServiceModule;
 
         // -- Parse JSON config file
         try (final InputStream configStream = context.getAssets().open(configFileName)) {
@@ -68,29 +70,6 @@ public final class MobileCore {
         } catch (JSONException | IOException exception) {
             String message = String.format("%s could not be loaded", configFileName);
             throw new InitializationException(message, exception);
-        }
-
-        // -- Set the app version variable
-        appVersion = getAppVersion(context);
-
-        // -- Setting default http layer
-        if (options.httpServiceModule == null) {
-            OkHttpClient.Builder builder = new OkHttpClient.Builder();
-            builder.connectTimeout(DEFAULT_CONNECT_TIMEOUT, TimeUnit.SECONDS)
-                            .writeTimeout(DEFAULT_WRITE_TIMEOUT, TimeUnit.SECONDS)
-                            .readTimeout(DEFAULT_READ_TIMEOUT, TimeUnit.SECONDS);
-            final OkHttpServiceModule httpServiceModule = new OkHttpServiceModule(builder.build());
-
-            ServiceConfiguration configuration = this.servicesConfig.get(httpServiceModule.type());
-            if (configuration == null) {
-                configuration = new ServiceConfiguration.Builder().build();
-            }
-
-            httpServiceModule.configure(this, configuration);
-
-            this.httpLayer = httpServiceModule;
-        } else {
-            this.httpLayer = options.httpServiceModule;
         }
     }
 
@@ -100,8 +79,8 @@ public final class MobileCore {
      * @param context Application context
      * @return MobileCore instance
      */
-    public static MobileCore init(final Context context) throws InitializationException {
-        return init(context, new Options());
+    public static void init(final Context context) throws InitializationException {
+        init(context, new Options());
     }
 
     /**
@@ -111,34 +90,38 @@ public final class MobileCore {
      * @param options AeroGear initialization options
      * @return MobileCore instance
      */
-    public static MobileCore init(final Context context, final Options options)
+    public static void init(final Context context, final Options options)
                     throws InitializationException {
-        return new MobileCore(context, options);
+        instance = new MobileCore(context, options);
+    }
+
+    public static MobileCore getInstance() {
+        return instance;
     }
 
     /**
      * Called when mobile core instance needs to be destroyed
      */
-    public void destroy() {
-        for (Class<? extends ServiceModule> serviceKey : services.keySet()) {
-            ServiceModule serviceModule = services.get(serviceKey);
+    public static void destroy() {
+        for (Class<? extends ServiceModule> serviceKey : instance.services.keySet()) {
+            ServiceModule serviceModule = instance.services.get(serviceKey);
             serviceModule.destroy();
         }
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends ServiceModule> T getInstance(final Class<T> serviceClass) {
-        return (T) getInstance(serviceClass, null);
+    public static <T extends ServiceModule> T getInstance(final Class<T> serviceClass) {
+        return getInstance(serviceClass, null);
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends ServiceModule> T getInstance(final Class<T> serviceClass,
+    public static <T extends ServiceModule> T getInstance(final Class<T> serviceClass,
                     final ServiceConfiguration serviceConfiguration)
                     throws InitializationException {
         nonNull(serviceClass, "serviceClass");
 
-        if (services.containsKey(serviceClass)) {
-            return (T) services.get(serviceClass);
+        if (instance.services.containsKey(serviceClass)) {
+            return (T) instance.services.get(serviceClass);
         }
 
         try {
@@ -147,17 +130,17 @@ public final class MobileCore {
             ServiceConfiguration serviceCfg = serviceConfiguration;
 
             if (serviceCfg == null) {
-                serviceCfg = getServiceConfiguration(serviceModule.type());
+                serviceCfg = instance.getServiceConfiguration(serviceModule.type());
             }
 
             if (serviceCfg == null && serviceModule.requiresConfiguration()) {
                 throw new ConfigurationNotFoundException(
-                                serviceModule.type() + " not found on " + this.configFileName);
+                                serviceModule.type() + " not found on " + instance.configFileName);
             }
 
-            serviceModule.configure(this, serviceCfg);
+            serviceModule.configure(instance, serviceCfg);
 
-            services.put(serviceClass, serviceModule);
+            instance.services.put(serviceClass, serviceModule);
 
             return (T) serviceModule;
 
@@ -173,7 +156,7 @@ public final class MobileCore {
      */
 
     public Context getContext() {
-        return context;
+        return instance.context;
     }
 
     /**
@@ -183,7 +166,7 @@ public final class MobileCore {
      * @return the configuration for this singleThreadService from the JSON config file
      */
     public ServiceConfiguration getServiceConfiguration(final String type) {
-        return this.servicesConfig.get(type);
+        return instance.servicesConfig.get(type);
     }
 
     /**
@@ -204,16 +187,16 @@ public final class MobileCore {
     }
 
     public HttpServiceModule getHttpLayer() {
-        return this.httpLayer;
+        return instance.httpLayer;
     }
 
-    public static Logger getLogger() {
-        return logger;
+    public Logger getLogger() {
+        return instance.logger;
     }
 
     @VisibleForTesting()
     public String getConfigFileName() {
-        return configFileName;
+        return instance.configFileName;
     }
 
     /**
@@ -221,7 +204,7 @@ public final class MobileCore {
      *
      * @return String SDK version
      */
-    public static String getSdkVersion() {
+    public String getSdkVersion() {
         return BuildConfig.VERSION_NAME;
     }
 
@@ -230,19 +213,27 @@ public final class MobileCore {
      *
      * @return String App version name
      */
-    public static String getAppVersion() {
-        return appVersion;
+    public String getAppVersion() {
+        return instance.appVersion;
     }
 
     @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public static final class Options {
 
-        private String configFileName = DEFAULT_CONFIG_FILE_NAME;
-        // Don't have a default implementation because it should use configuration
+        private String configFileName;
+        private Logger logger;
         private HttpServiceModule httpServiceModule;
-        private Logger logger = new LoggerAdapter();
 
-        public Options() {}
+        public Options() {
+            this.configFileName = DEFAULT_CONFIG_FILE_NAME;
+            this.logger = new LoggerAdapter();
+
+            OkHttpClient.Builder builder = new OkHttpClient.Builder();
+            builder.connectTimeout(DEFAULT_CONNECT_TIMEOUT, TimeUnit.SECONDS)
+                            .writeTimeout(DEFAULT_WRITE_TIMEOUT, TimeUnit.SECONDS)
+                            .readTimeout(DEFAULT_READ_TIMEOUT, TimeUnit.SECONDS);
+            this.httpServiceModule = new OkHttpServiceModule(builder.build());
+        }
 
         public Options setConfigFileName(@NonNull final String configFileName) {
             this.configFileName = nonNull(configFileName, "configFileName");

--- a/core/src/main/java/org/aerogear/mobile/core/bootstrap/AeroGearBootstrap.java
+++ b/core/src/main/java/org/aerogear/mobile/core/bootstrap/AeroGearBootstrap.java
@@ -1,0 +1,51 @@
+package org.aerogear.mobile.core.bootstrap;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.aerogear.mobile.core.MobileCore;
+
+public class AeroGearBootstrap extends ContentProvider {
+
+    @Override
+    public boolean onCreate() {
+        MobileCore.init(getContext());
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection,
+                    @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection,
+                    @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection,
+                    @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+}

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -38,12 +38,11 @@ public class MetricsService implements ServiceModule {
         nonNull(core, "mobileCore");
         nonNull(serviceConfiguration, "serviceConfiguration");
 
-        defaultMetrics = new Metrics[] {new AppMetrics(core.getContext()),
-                        new DeviceMetrics(core.getContext())};
+        defaultMetrics = new Metrics[] {new AppMetrics(core.getContext()), new DeviceMetrics()};
 
         final String metricsUrl = serviceConfiguration.getUrl();
         if (metricsUrl == null) {
-            publisher = new LoggerMetricsPublisher(MobileCore.getLogger());
+            publisher = new LoggerMetricsPublisher(core.getLogger());
         } else {
             publisher = new NetworkMetricsPublisher(core.getContext(),
                             core.getHttpLayer().newRequest(), metricsUrl);

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -91,7 +91,7 @@ public class MetricsService implements ServiceModule {
     public void publish(@NonNull final Metrics[] metrics, final Callback callback) {
         if (publisher == null) {
             throw new IllegalStateException(
-                            "Make sure you have called configure or get this instance from MobileCore.getInstance()");
+                            "Make sure you have called configure or get this instance from MobileCore.getInstance().getService()");
         }
         nonNull(metrics, "metrics");
         publisher.publish(metrics, callback);

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/AppMetrics.java
@@ -21,8 +21,8 @@ public class AppMetrics implements Metrics<JSONObject> {
 
     public AppMetrics(final Context context) {
         this.appId = nonNull(context, "context").getPackageName();
-        this.appVersion = MobileCore.getAppVersion();
-        this.sdkVersion = MobileCore.getSdkVersion();
+        this.appVersion = MobileCore.getInstance().getAppVersion();
+        this.sdkVersion = MobileCore.getInstance().getSdkVersion();
     }
 
     @Override
@@ -44,7 +44,7 @@ public class AppMetrics implements Metrics<JSONObject> {
             data.put("sdkVersion", sdkVersion);
             return data;
         } catch (JSONException e) {
-            MobileCore.getLogger().error("Error building JSON for App Metrics", e);
+            MobileCore.getInstance().getLogger().error("Error building JSON for App Metrics", e);
         }
         return data;
     }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
@@ -3,7 +3,6 @@ package org.aerogear.mobile.core.metrics.impl;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.content.Context;
 import android.os.Build;
 
 import org.aerogear.mobile.core.MobileCore;
@@ -18,7 +17,7 @@ public class DeviceMetrics implements Metrics<JSONObject> {
     private final String platform;
     private final String platformVersion;
 
-    public DeviceMetrics(final Context context) {
+    public DeviceMetrics() {
         this.platform = "android";
         this.platformVersion = String.valueOf(Build.VERSION.SDK_INT);
     }
@@ -35,7 +34,7 @@ public class DeviceMetrics implements Metrics<JSONObject> {
             data.put("platform", platform);
             data.put("platformVersion", platformVersion);
         } catch (JSONException e) {
-            MobileCore.getLogger().error("Error building JSON for Device Metrics", e);
+            MobileCore.getInstance().getLogger().error("Error building JSON for Device Metrics", e);
         }
         return data;
     }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -23,7 +23,7 @@ import org.aerogear.mobile.core.utils.ClientIdGenerator;
  */
 public class NetworkMetricsPublisher implements MetricsPublisher {
 
-    public static final Logger LOGGER = MobileCore.getLogger();
+    private static final Logger LOGGER = MobileCore.getInstance().getLogger();
 
     private final Context context;
     private final HttpRequest httpRequest;

--- a/core/src/main/java/org/aerogear/mobile/core/utils/ClientIdGenerator.java
+++ b/core/src/main/java/org/aerogear/mobile/core/utils/ClientIdGenerator.java
@@ -37,7 +37,7 @@ public final class ClientIdGenerator {
         if (clientId == null) {
             clientId = UUID.randomUUID().toString();
 
-            MobileCore.getLogger().info("Generated a new client ID: " + clientId);
+            MobileCore.getInstance().getLogger().info("Generated a new client ID: " + clientId);
 
             SharedPreferences.Editor editor = preferences.edit();
             editor.putString(STORAGE_KEY, clientId);

--- a/core/src/test/java/org/aerogear/mobile/core/ReactiveCaseTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/ReactiveCaseTest.java
@@ -31,14 +31,13 @@ import org.aerogear.mobile.core.reactive.Responder;
 @SmallTest
 public class ReactiveCaseTest {
 
-    private MobileCore core;
     private AppExecutors executor = new AppExecutors();
 
     @Before
     public void setUp() {
         Application context = RuntimeEnvironment.application;
 
-        core = MobileCore.init(context);
+        MobileCore.init(context);
     }
 
     /**

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -33,8 +33,8 @@ public class MetricsServiceIntegrationTest {
         MobileCore.Options options = new MobileCore.Options();
         options.setConfigFileName(MOBILE_SERVICES_JSON);
 
-        MobileCore mobileCore = MobileCore.init(RuntimeEnvironment.application, options);
-        metricsService = mobileCore.getInstance(MetricsService.class);
+        MobileCore.init(RuntimeEnvironment.application, options);
+        metricsService = MobileCore.getInstance().getService(MetricsService.class);
 
         error = null;
     }

--- a/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
-import android.app.Application;
+import android.content.Context;
 import android.support.test.filters.SmallTest;
 
 import org.aerogear.mobile.core.MobileCore;
@@ -25,7 +25,6 @@ import org.aerogear.mobile.core.http.HttpServiceModule;
 import org.aerogear.mobile.core.http.OkHttpServiceModule;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.logging.LoggerAdapter;
-import org.aerogear.mobile.core.metrics.MetricsService;
 
 @RunWith(RobolectricTestRunner.class)
 @SmallTest
@@ -34,30 +33,19 @@ public class MobileCoreTest {
     private static final String DUMMY_MOBILE_SERVICES_JSON = "dummy-mobile-services.json";
     private static final String EMPTY_MOBILE_SERVICES_JSON = "empty-mobile-services.json";
 
-    private MobileCore core;
-    private MobileCore dummyCore;
+    private Context context = RuntimeEnvironment.application;
 
     @Before
     public void setUp() throws Exception {
-        Application context = RuntimeEnvironment.application;
-
-        core = MobileCore.init(context);
-
-        MobileCore.Options options = new MobileCore.Options();
-        options.setConfigFileName(DUMMY_MOBILE_SERVICES_JSON);
-        dummyCore = MobileCore.init(context, options);
+        MobileCore.init(context);
     }
 
     @Test
-    public void testInit() {
-        // -- Http
-        assertEquals(OkHttpServiceModule.class, core.getHttpLayer().getClass());
-
-        // -- Logger
-        assertEquals(LoggerAdapter.class, core.getLogger().getClass());
-
-        // -- Metrics
-        assertEquals(MetricsService.class, core.getInstance(MetricsService.class).getClass());
+    public void testDefaultOptions() {
+        assertEquals(MobileCore.DEFAULT_CONFIG_FILE_NAME,
+                        MobileCore.getInstance().getConfigFileName());
+        assertEquals(LoggerAdapter.class, MobileCore.getInstance().getLogger().getClass());
+        assertEquals(OkHttpServiceModule.class, MobileCore.getInstance().getHttpLayer().getClass());
     }
 
     @Test(expected = RuntimeException.class)
@@ -67,49 +55,42 @@ public class MobileCoreTest {
 
     @Test(expected = RuntimeException.class)
     public void testInitWithNullOptions() throws Exception {
-        MobileCore.init(null, null);
-    }
-
-    @Test
-    public void testDefaultConfigFile() throws Exception {
-        assertEquals(MobileCore.DEFAULT_CONFIG_FILE_NAME, core.getConfigFileName());
+        MobileCore.init(context, null);
     }
 
     @Test
     public void testInitWithDifferentHttpServiceModule() {
-        Application context = RuntimeEnvironment.application;
-
         MobileCore.Options options = new MobileCore.Options();
         options.setHttpServiceModule(new DummyHttpServiceModule());
 
-        MobileCore core = MobileCore.init(context, options);
+        MobileCore.init(context, options);
 
-        assertEquals(DummyHttpServiceModule.class, core.getHttpLayer().getClass());
+        assertEquals(DummyHttpServiceModule.class,
+                        MobileCore.getInstance().getHttpLayer().getClass());
     }
 
     @Test
     public void testInitWithDifferentConfigFile() {
-        DummyHttpServiceModule service = dummyCore.getInstance(DummyHttpServiceModule.class);
+        MobileCore.Options options = new MobileCore.Options();
+        options.setConfigFileName(DUMMY_MOBILE_SERVICES_JSON);
 
-        assertEquals("http://dummy.net", service.getUrl());
+        MobileCore.init(context, options);
+
+        // assertEquals("http://dummy.net", service.getUrl());
     }
 
     @Test
     public void testInitWithDifferentLogger() {
-        Application context = RuntimeEnvironment.application;
-
         MobileCore.Options options = new MobileCore.Options();
         options.setLogger(new DummyLogger());
 
-        MobileCore core = MobileCore.init(context, options);
+        MobileCore.init(context, options);
 
-        assertEquals(DummyLogger.class, core.getLogger().getClass());
+        assertEquals(DummyLogger.class, MobileCore.getInstance().getLogger().getClass());
     }
 
     @Test(expected = InitializationException.class)
     public void testInitWithNonExistentConfigFile() {
-        Application context = RuntimeEnvironment.application;
-
         MobileCore.Options options = new MobileCore.Options();
         options.setConfigFileName("wrong-file-name.json");
 
@@ -118,40 +99,46 @@ public class MobileCoreTest {
 
     @Test
     public void testConfigurationNotRequiredDoesNotThrowException() {
-        core.getInstance(DummyServiceModule.class);
+        MobileCore.getInstance(DummyServiceModule.class);
     }
 
     @Test(expected = ConfigurationNotFoundException.class)
     public void testUnregisteredServiceThrowsException() {
-        Application context = RuntimeEnvironment.application;
-
         MobileCore.Options options = new MobileCore.Options();
         options.setConfigFileName(EMPTY_MOBILE_SERVICES_JSON);
-        MobileCore emptyCore = MobileCore.init(context, options);
 
-        emptyCore.getInstance(DummyHttpServiceModule.class);
+        MobileCore.init(context, options);
+
+        MobileCore.getInstance(DummyHttpServiceModule.class);
     }
 
     @Test
     public void testInitDoesNotThrowIfMetricsNotRegistered() throws Exception {
-        Application context = RuntimeEnvironment.application;
-
         MobileCore.Options options = new MobileCore.Options();
         options.setConfigFileName(EMPTY_MOBILE_SERVICES_JSON);
+
         MobileCore.init(context, options);
     }
 
     @Test
     public void testGetInstance() {
-        DummyHttpServiceModule service = dummyCore.getInstance(DummyHttpServiceModule.class);
+        MobileCore.Options options = new MobileCore.Options();
+        options.setConfigFileName(DUMMY_MOBILE_SERVICES_JSON);
+        MobileCore.init(context, options);
+
+        DummyHttpServiceModule service = MobileCore.getInstance(DummyHttpServiceModule.class);
 
         assertNotNull(service);
     }
 
     @Test
     public void testGetCachedInstance() {
-        DummyHttpServiceModule service1 = dummyCore.getInstance(DummyHttpServiceModule.class);
-        DummyHttpServiceModule service2 = dummyCore.getInstance(DummyHttpServiceModule.class);
+        MobileCore.Options options = new MobileCore.Options();
+        options.setConfigFileName(DUMMY_MOBILE_SERVICES_JSON);
+        MobileCore.init(context, options);
+
+        DummyHttpServiceModule service1 = MobileCore.getInstance(DummyHttpServiceModule.class);
+        DummyHttpServiceModule service2 = MobileCore.getInstance(DummyHttpServiceModule.class);
 
         assertNotNull(service1);
         assertNotNull(service2);
@@ -160,13 +147,15 @@ public class MobileCoreTest {
 
     @Test
     public void testAllServicesAreDestroyed() throws Exception {
-        DummyServiceModule service1 = dummyCore.getInstance(DummyServiceModule.class);
-        DummyServiceModule service2 = dummyCore.getInstance(DummyServiceModule.class);
+        MobileCore.init(context);
+
+        DummyServiceModule service1 = MobileCore.getInstance(DummyServiceModule.class);
+        DummyServiceModule service2 = MobileCore.getInstance(DummyServiceModule.class);
 
         Assert.assertFalse(service1.isDestroyed());
         Assert.assertFalse(service2.isDestroyed());
 
-        dummyCore.destroy();
+        MobileCore.destroy();
 
         Assert.assertTrue(service1.isDestroyed());
         Assert.assertTrue(service2.isDestroyed());
@@ -174,7 +163,10 @@ public class MobileCoreTest {
 
     @Test
     public void testGetServiceConfiguration() {
-        ServiceConfiguration serviceConfiguration = core.getServiceConfiguration("keycloak");
+        MobileCore.init(context);
+
+        ServiceConfiguration serviceConfiguration =
+                        MobileCore.getInstance().getServiceConfiguration("keycloak");
 
         String url = "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6";
         assertEquals(url, serviceConfiguration.getUrl());

--- a/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
@@ -99,7 +99,7 @@ public class MobileCoreTest {
 
     @Test
     public void testConfigurationNotRequiredDoesNotThrowException() {
-        MobileCore.getInstance(DummyServiceModule.class);
+        MobileCore.getInstance().getService(DummyServiceModule.class);
     }
 
     @Test(expected = ConfigurationNotFoundException.class)
@@ -109,7 +109,7 @@ public class MobileCoreTest {
 
         MobileCore.init(context, options);
 
-        MobileCore.getInstance(DummyHttpServiceModule.class);
+        MobileCore.getInstance().getService(DummyHttpServiceModule.class);
     }
 
     @Test
@@ -126,7 +126,8 @@ public class MobileCoreTest {
         options.setConfigFileName(DUMMY_MOBILE_SERVICES_JSON);
         MobileCore.init(context, options);
 
-        DummyHttpServiceModule service = MobileCore.getInstance(DummyHttpServiceModule.class);
+        DummyHttpServiceModule service =
+                        MobileCore.getInstance().getService(DummyHttpServiceModule.class);
 
         assertNotNull(service);
     }
@@ -137,8 +138,10 @@ public class MobileCoreTest {
         options.setConfigFileName(DUMMY_MOBILE_SERVICES_JSON);
         MobileCore.init(context, options);
 
-        DummyHttpServiceModule service1 = MobileCore.getInstance(DummyHttpServiceModule.class);
-        DummyHttpServiceModule service2 = MobileCore.getInstance(DummyHttpServiceModule.class);
+        DummyHttpServiceModule service1 =
+                        MobileCore.getInstance().getService(DummyHttpServiceModule.class);
+        DummyHttpServiceModule service2 =
+                        MobileCore.getInstance().getService(DummyHttpServiceModule.class);
 
         assertNotNull(service1);
         assertNotNull(service2);
@@ -149,8 +152,8 @@ public class MobileCoreTest {
     public void testAllServicesAreDestroyed() throws Exception {
         MobileCore.init(context);
 
-        DummyServiceModule service1 = MobileCore.getInstance(DummyServiceModule.class);
-        DummyServiceModule service2 = MobileCore.getInstance(DummyServiceModule.class);
+        DummyServiceModule service1 = MobileCore.getInstance().getService(DummyServiceModule.class);
+        DummyServiceModule service2 = MobileCore.getInstance().getService(DummyServiceModule.class);
 
         Assert.assertFalse(service1.isDestroyed());
         Assert.assertFalse(service2.isDestroyed());

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
@@ -27,12 +27,11 @@ import org.aerogear.mobile.core.metrics.publisher.NetworkMetricsPublisher;
 @SmallTest
 public class MetricsServiceTest {
 
-    MobileCore mobileCore;
     MetricsService metricsService;
 
     @Before
     public void setUp() throws Exception {
-        mobileCore = MobileCore.init(RuntimeEnvironment.application);
+        MobileCore.init(RuntimeEnvironment.application);
         metricsService = new MetricsService();
     }
 
@@ -46,7 +45,7 @@ public class MetricsServiceTest {
     public void defaultPublisherWithoutConfigUrl() {
         ServiceConfiguration serviceConfiguration = new ServiceConfiguration.Builder().build();
 
-        metricsService.configure(mobileCore, serviceConfiguration);
+        metricsService.configure(MobileCore.getInstance(), serviceConfiguration);
 
         assertEquals(LoggerMetricsPublisher.class, metricsService.getPublisher().getClass());
     }
@@ -56,7 +55,7 @@ public class MetricsServiceTest {
         ServiceConfiguration serviceConfiguration =
                         new ServiceConfiguration.Builder().setUrl("http://dummy.url").build();
 
-        metricsService.configure(mobileCore, serviceConfiguration);
+        metricsService.configure(MobileCore.getInstance(), serviceConfiguration);
 
         assertEquals(NetworkMetricsPublisher.class, metricsService.getPublisher().getClass());
     }
@@ -73,7 +72,8 @@ public class MetricsServiceTest {
 
     @Test
     public void testCallbackSuccessMethodIsCalled() throws Exception {
-        metricsService.configure(mobileCore, new ServiceConfiguration.Builder().build());
+        metricsService.configure(MobileCore.getInstance(),
+                        new ServiceConfiguration.Builder().build());
 
         final Callback testCallback = new Callback() {
             @Override
@@ -95,7 +95,7 @@ public class MetricsServiceTest {
     public void testCallbackErrorMethodIsCalled() throws Exception {
         ServiceConfiguration serviceConfiguration =
                         new ServiceConfiguration.Builder().setUrl("http://dummy").build();
-        metricsService.configure(mobileCore, serviceConfiguration);
+        metricsService.configure(MobileCore.getInstance(), serviceConfiguration);
 
         final Callback testCallback = new Callback() {
             @Override

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/DeviceMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/DeviceMetricsTest.java
@@ -23,7 +23,7 @@ public class DeviceMetricsTest {
     public void testType() {
         Application context = RuntimeEnvironment.application;
 
-        DeviceMetrics deviceMetrics = new DeviceMetrics(context);
+        DeviceMetrics deviceMetrics = new DeviceMetrics();
         assertEquals("device", deviceMetrics.identifier());
     }
 
@@ -31,7 +31,7 @@ public class DeviceMetricsTest {
     public void testData() throws JSONException {
         Application context = RuntimeEnvironment.application;
 
-        DeviceMetrics deviceMetrics = new DeviceMetrics(context);
+        DeviceMetrics deviceMetrics = new DeviceMetrics();
         JSONObject result = deviceMetrics.data();
 
         assertNotNull(result.getString("platform"));

--- a/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
@@ -2,43 +2,25 @@ package org.aerogear.mobile.example;
 
 import android.app.Application;
 
-import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.MetricsService;
 
 public class ExampleApplication extends Application {
 
-    private MobileCore mobileCore;
-    private MetricsService metricsService;
-
     @Override
     public void onCreate() {
         super.onCreate();
 
-        mobileCore = MobileCore.init(this);
-        metricsService = mobileCore.getInstance(MetricsService.class);
-
-        metricsService.sendAppAndDeviceMetrics(new Callback() {
-            @Override
-            public void onError(Throwable error) {
-                MobileCore.getLogger().error(error.getMessage());
-            }
-        });
+        MetricsService metricsService = MobileCore.getInstance(MetricsService.class);
+        metricsService.sendAppAndDeviceMetrics(
+                        error -> MobileCore.getInstance().getLogger().error(error.getMessage()));
     }
 
     @Override
     public void onTerminate() {
         super.onTerminate();
 
-        mobileCore.destroy();
-    }
-
-    public MobileCore getMobileCore() {
-        return mobileCore;
-    }
-
-    public MetricsService getMetricsService() {
-        return metricsService;
+        MobileCore.destroy();
     }
 
 }

--- a/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
@@ -11,7 +11,7 @@ public class ExampleApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        MetricsService metricsService = MobileCore.getInstance(MetricsService.class);
+        MetricsService metricsService = MobileCore.getInstance().getService(MetricsService.class);
         metricsService.sendAppAndDeviceMetrics(
                         error -> MobileCore.getInstance().getLogger().error(error.getMessage()));
     }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/BaseActivity.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/BaseActivity.java
@@ -4,24 +4,14 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
-import org.aerogear.mobile.core.MobileCore;
-import org.aerogear.mobile.core.metrics.MetricsService;
-import org.aerogear.mobile.example.ExampleApplication;
-
 /**
  * Base class for all activities that want to work with AeroGearServices SDK
  */
 public abstract class BaseActivity extends AppCompatActivity {
 
-    protected MobileCore mobileCore;
-    protected MetricsService metricsService;
-
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        ExampleApplication application = (ExampleApplication) getApplication();
-        mobileCore = application.getMobileCore();
-        metricsService = application.getMetricsService();
     }
+
 }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/HttpFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/HttpFragment.java
@@ -12,6 +12,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;
@@ -41,7 +42,7 @@ public class HttpFragment extends BaseFragment {
 
         new LastAdapter(users, BR.user).map(User.class, R.layout.item_http).into(userList);
 
-        HttpRequest httpRequest = activity.mobileCore.getHttpLayer().newRequest();
+        HttpRequest httpRequest = MobileCore.getInstance().getHttpLayer().newRequest();
         httpRequest.get("https://jsonplaceholder.typicode.com/users");
         HttpResponse httpResponse = httpRequest.execute();
         httpResponse.onComplete(() -> {
@@ -51,7 +52,7 @@ public class HttpFragment extends BaseFragment {
                 List<User> retrievesUsers = new Gson().fromJson(jsonResponse,
                                 new TypeToken<List<User>>() {}.getType());
 
-                activity.mobileCore.getLogger().info("Users: " + retrievesUsers.size());
+                MobileCore.getInstance().getLogger().info("Users: " + retrievesUsers.size());
 
                 users.addAll(retrievesUsers);
             });

--- a/example/src/main/java/org/aerogear/mobile/example/ui/MainActivity.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/MainActivity.java
@@ -48,7 +48,7 @@ public class MainActivity extends BaseActivity
         drawer.addDrawerListener(toggle);
         toggle.syncState();
 
-        authService = MobileCore.getInstance(AuthService.class);
+        authService = MobileCore.getInstance().getService(AuthService.class);
         AuthServiceConfiguration authServiceConfiguration =
                         new AuthServiceConfiguration.AuthConfigurationBuilder()
                                         .withRedirectUri("org.aerogear.mobile.example:/callback")

--- a/example/src/main/java/org/aerogear/mobile/example/ui/MainActivity.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/MainActivity.java
@@ -14,6 +14,7 @@ import android.view.MenuItem;
 import org.aerogear.mobile.auth.AuthService;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.auth.user.UserPrincipal;
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.example.R;
 
 import butterknife.BindView;
@@ -47,7 +48,7 @@ public class MainActivity extends BaseActivity
         drawer.addDrawerListener(toggle);
         toggle.syncState();
 
-        authService = (AuthService) mobileCore.getInstance(AuthService.class);
+        authService = MobileCore.getInstance(AuthService.class);
         AuthServiceConfiguration authServiceConfiguration =
                         new AuthServiceConfiguration.AuthConfigurationBuilder()
                                         .withRedirectUri("org.aerogear.mobile.example:/callback")

--- a/example/src/main/java/org/aerogear/mobile/example/ui/SecurityServiceFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/SecurityServiceFragment.java
@@ -73,7 +73,7 @@ public class SecurityServiceFragment extends BaseFragment {
     @Override
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        securityService = MobileCore.getInstance(SecurityService.class);
+        securityService = MobileCore.getInstance().getService(SecurityService.class);
         runTests();
     }
 
@@ -89,8 +89,9 @@ public class SecurityServiceFragment extends BaseFragment {
                         .withSecurityCheck(SecurityCheckType.IS_EMULATOR)
                         .withSecurityCheck(SecurityCheckType.IS_DEBUGGER)
                         .withSecurityCheck(SecurityCheckType.IS_DEVELOPER_MODE)
-                        .withMetricsService(MobileCore.getInstance(MetricsService.class)).build()
-                        .execute();
+                        .withMetricsService(
+                                        MobileCore.getInstance().getService(MetricsService.class))
+                        .build().execute();
 
         // perform detections
         detectRoot(results);

--- a/example/src/main/java/org/aerogear/mobile/example/ui/SecurityServiceFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/SecurityServiceFragment.java
@@ -10,6 +10,7 @@ import android.widget.ProgressBar;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.MetricsService;
 import org.aerogear.mobile.example.R;
 import org.aerogear.mobile.security.SecurityCheckExecutor;
@@ -72,7 +73,7 @@ public class SecurityServiceFragment extends BaseFragment {
     @Override
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        securityService = activity.mobileCore.getInstance(SecurityService.class);
+        securityService = MobileCore.getInstance(SecurityService.class);
         runTests();
     }
 
@@ -88,8 +89,8 @@ public class SecurityServiceFragment extends BaseFragment {
                         .withSecurityCheck(SecurityCheckType.IS_EMULATOR)
                         .withSecurityCheck(SecurityCheckType.IS_DEBUGGER)
                         .withSecurityCheck(SecurityCheckType.IS_DEVELOPER_MODE)
-                        .withMetricsService(activity.mobileCore.getInstance(MetricsService.class))
-                        .build().execute();
+                        .withMetricsService(MobileCore.getInstance(MetricsService.class)).build()
+                        .execute();
 
         // perform detections
         detectRoot(results);


### PR DESCRIPTION
Today dev needs to explicit call `MobileCore.init()` before doing anything else related to AeroGear.  This PR make the `MobileCore.init()` be called by the Android lifecycle, **before** app starts (Application, Services, etc...)

It's based on the Firebase blog post: [How does Firebase initialize on Android](https://firebase.googleblog.com/2016/12/how-does-firebase-initialize-on-android.html)

This is part of the work I'm doing to decouple Services creation from the MobileCore ([AGDROID-796](https://issues.jboss.org/browse/AGDROID-796))

PS: Developer will still be able to call init with options with needs.