### PR TITLE
Replace Spring dependency management by a single gradle file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-26-alpha
+      - image: circleci/android:api-27-alpha
     environment:
       JVM_OPTS: -Xmx3200m
     steps:

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
 
 android {
     compileSdkVersion project.ext.targetSdkVersion
@@ -6,14 +6,15 @@ android {
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
+
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = ['appAuthRedirectScheme': 'org.aerogear.mobile.example']
+        manifestPlaceholders = ["appAuthRedirectScheme": "org.aerogear.mobile.example"]
     }
 
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
 
@@ -31,15 +32,15 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':core')
-    implementation 'net.openid:appauth'
-    implementation 'com.android.support:customtabs:26.1.0'
-    implementation ('net.openid:appauth', { exclude group: 'com.android.support', module: 'customtabs' })
-    implementation 'org.bitbucket.b_c:jose4j'
-    implementation 'com.scottyab:rootbeer-lib:0.0.6'
-    testImplementation 'junit:junit'
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.robolectric:robolectric'
+    implementation project(path: ":core")
+    implementation "net.openid:appauth:${project.ext.appauth_version}"
+    implementation "com.android.support:customtabs:${project.ext.android_support_version}"
+    implementation "org.bitbucket.b_c:jose4j:${project.ext.jose4j_version}"
+    implementation "com.scottyab:rootbeer-lib:${project.ext.rootbeer_version}"
+
+    testImplementation "junit:junit:${project.ext.junit_version}"
+    testImplementation "org.mockito:mockito-core:${project.ext.mockito_version}"
+    testImplementation "org.robolectric:robolectric:${project.ext.robolectric_version}"
 }
 
 apply from: "../gradle-mvn-push.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,9 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 
     }
-
 }
 
 plugins {
-    id "io.spring.dependency-management" version "1.0.4.RELEASE"
     id "com.diffplug.gradle.spotless" version "3.10.0"
 }
 
@@ -26,14 +24,8 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'io.spring.dependency-management'
     apply plugin: "com.diffplug.gradle.spotless"
 
-    dependencyManagement {
-        imports {
-            mavenBom 'org.jboss.aerogear:aerogear-android-sdk-bom:1.1.11'
-        }
-    }
     spotless {
         java {
             target '**/*.java'

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,5 +1,25 @@
 project.ext {
+    // Global
+
     minSdkVersion = 21
-    compileSdkVersion = 26
-    targetSdkVersion = 26
+    compileSdkVersion = 27
+    targetSdkVersion = 27
+    android_support_version = "27.1.0"
+
+    // Test
+    junit_version = "4.12"
+    android_support_test_runner_version = "1.0.1"
+    android_support_test_rules_version = "1.0.1"
+    android_support_test_espresso_version = "3.0.1"
+    mockito_version = "2.10.0"
+    robolectric_version = "3.6.1"
+    json_version = "20180130"
+
+    // Core
+    okhttp_version = "3.9.1"
+
+    // Auth
+    appauth_version = "0.7.0"
+    jose4j_version = "0.6.3"
+    rootbeer_version = "0.0.6"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,16 +35,16 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7"
-    implementation "com.squareup.okhttp3:okhttp"
+    implementation "com.android.support:appcompat-v7:${project.ext.android_support_version}"
+    implementation "com.squareup.okhttp3:okhttp:${project.ext.okhttp_version}"
 
-    testImplementation "junit:junit"
-    testImplementation "com.android.support.test:runner"
-    testImplementation "com.android.support.test:rules"
-    testImplementation "com.android.support.test.espresso:espresso-core"
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation "org.robolectric:robolectric"
-    testImplementation "com.squareup.okhttp3:mockwebserver"
+    testImplementation "junit:junit:${project.ext.junit_version}"
+    testImplementation "com.android.support.test:runner:${project.ext.android_support_test_runner_version}"
+    testImplementation "com.android.support.test:rules:${project.ext.android_support_test_rules_version}"
+    testImplementation "com.android.support.test.espresso:espresso-core:${project.ext.android_support_test_espresso_version}"
+    testImplementation "org.mockito:mockito-core:${project.ext.mockito_version}"
+    testImplementation "org.robolectric:robolectric:${project.ext.robolectric_version}"
+    testImplementation "com.squareup.okhttp3:mockwebserver:${project.ext.okhttp_version}"
 }
 
 apply from: "../gradle-mvn-push.gradle"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -8,11 +8,8 @@ android {
     defaultConfig {
         applicationId "org.aerogear.mobile.example"
 
-        minSdkVersion 21
-        targetSdkVersion 27
-
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
 
         manifestPlaceholders = ['appAuthRedirectScheme': 'org.aerogear.mobile.example']
 
@@ -31,19 +28,17 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
-}
-
-ext {
-    android_support_version = "27.0.2"
 }
 
 dependencies {
     implementation project(path: ":core")
     implementation project(path: ":auth")
-    implementation "com.android.support:appcompat-v7:$android_support_version"
-    implementation "com.android.support:support-v4:$android_support_version"
-    implementation "com.android.support:design:$android_support_version"
+
+    implementation "com.android.support:appcompat-v7:${project.ext.android_support_version}"
+    implementation "com.android.support:support-v4:${project.ext.android_support_version}"
+    implementation "com.android.support:design:${project.ext.android_support_version}"
+
+    // Dependencies used on the app but not on the libraries should not be in the constants.gradle
     implementation "com.android.support.constraint:constraint-layout:1.0.2"
     implementation "com.jakewharton:butterknife:8.8.1"
     annotationProcessor "com.jakewharton:butterknife-compiler:8.8.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 03 14:50:46 BRST 2018
+#Thu Mar 29 15:29:36 BRT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
While working on push stuff I figure out [Spring dependency management](https://github.com/spring-gradle-plugins/dependency-management-plugin) doesn't work properly with [Gradle transitive dependencies](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html). 

It's ignoring the transitive dependencies and on push, it causes some dependency conflicts. Since Google Services plugin doesn't found any dependency it's going to inject it from your on.

```
Android dependency 'com.google.firebase:firebase-iid' has different version for the compile (11.4.2) and runtime (12.0.1) classpath. 
```
This PR moves all our dependencies version for a [single file](https://github.com/aerogear/aerogear-android-sdk/blob/master/constants.gradle) like most of the libraries do.

Related issues: 

* [AGDROID-799](https://issues.jboss.org/browse/AGDROID-799)