### PR TITLE
Excaping the windows path separator in the build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
         }
 
         android.buildTypes.each { type ->
-            type.buildConfigField 'String', 'PROJECT_ROOT', "\"" + project.projectDir.absolutePath + "/\""
+            type.buildConfigField 'String', 'PROJECT_ROOT', "\"" + project.projectDir.absolutePath.replace("\\","\\\\") + "/\""
         }
 
     }


### PR DESCRIPTION
## Motivation

We use a BuildConfig variable to configure the location of json config files.  When Gradle generated this variable under windows it does not escape the path correctly.  This fix escapes "\" on windows as "\\"
