### PR TITLE
Make HTTP response calling error callback on 400 or 500

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/exception/HttpException.java
+++ b/core/src/main/java/org/aerogear/mobile/core/exception/HttpException.java
@@ -1,4 +1,29 @@
 package org.aerogear.mobile.core.exception;
 
+/**
+ * Thrown when an HTTP error happens such as an HTTP response with status 40x or 50x.
+ * <p>
+ * Connection problems (hostname resolution, timeout, etc.) don't fall into this category. They're
+ * essentially IOExceptions.
+ */
 public class HttpException extends RuntimeException {
+    private final int statusCode;
+
+    public HttpException(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public HttpException(int statusCode, String message) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Get HTTP status code for this exception.
+     *
+     * @return HTTP status code
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
 }

--- a/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
@@ -62,7 +62,7 @@ public interface HttpResponse {
 
     /**
      * Returns the request error if it failed
-     * 
+     *
      * @return Exception request error or null
      */
     Exception getError();

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
@@ -101,7 +101,8 @@ class OkHttpResponse implements HttpResponse {
     @Override
     public HttpResponse onSuccess(Runnable successHandler) {
         this.successHandler = successHandler;
-        // If there is _any_ response and it is successful the success handler should run immediately
+        // If there is _any_ response and it is successful the success handler should run
+        // immediately
         if (response != null && (response.isSuccessful() || response.isRedirect())) {
             runSuccessHandler();
         }

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
@@ -30,7 +30,7 @@ class OkHttpResponse implements HttpResponse {
                 response = okHttpCall.execute();
                 requestCompleteLatch.countDown();
 
-                if(response.isSuccessful()) {
+                if (response.isSuccessful() || response.isRedirect()) {
                     // status 200 or 300
                     runSuccessHandler();
                 } else {

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 
+import org.aerogear.mobile.core.exception.HttpException;
 import org.aerogear.mobile.core.executor.AppExecutors;
 
 import okhttp3.Call;
@@ -35,7 +36,7 @@ class OkHttpResponse implements HttpResponse {
                     runSuccessHandler();
                 } else {
                     // status 400 or 500
-                    error = new Exception(response.message());
+                    error = new HttpException(response.code(), response.message());
                     runErrorHandler();
                 }
             } catch (SSLPeerUnverifiedException e) {

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpResponse.java
@@ -30,7 +30,7 @@ class OkHttpResponse implements HttpResponse {
                 response = okHttpCall.execute();
                 requestCompleteLatch.countDown();
 
-                if(response.isSuccessful()){
+                if(response.isSuccessful()) {
                     // status 200 or 300
                     runSuccessHandler();
                 } else {

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -143,7 +143,7 @@ public class PushService implements ServiceModule {
                         callback.onSuccess();
                         break;
                     default:
-                        callback.onError(new HttpException());
+                        callback.onError(new HttpException(httpResponse.getStatus()));
                         break;
                 }
             });
@@ -191,7 +191,7 @@ public class PushService implements ServiceModule {
                     callback.onSuccess();
                     break;
                 default:
-                    callback.onError(new HttpException());
+                    callback.onError(new HttpException(httpResponse.getStatus()));
                     break;
             }
         });


### PR DESCRIPTION
## Motivation

While working on https://issues.jboss.org/browse/AEROGEAR-2395 , I noticed the metrics related integration tests pass all the time.

As written in  <https://square.github.io/okhttp/3.x/okhttp/okhttp3/Call.html#execute--> , execute method does not throw an exception when status is 400 or 500. It only throws an exception when there's a connection problem.

But dependent code assumes that `onError` is called when 400 or 500.

To test the wrong behavior, just run the integration tests without the change in the PR. Even when the URL in integration-test-mobile-services.json is something that returns 500, it will pass. Just copy paste metrics service url, but change a letter so that it returns "503 - Service unavailable". 

