### PR TITLE
Remove clientID from mobile-services.json

### DIFF
--- a/example/src/main/assets/mobile-services.json
+++ b/example/src/main/assets/mobile-services.json
@@ -11,7 +11,6 @@
             "url": "https://keycloak.security.feedhenry.org",
             "config": {
                 "auth-server-url": "https://keycloak.security.feedhenry.org/auth",
-                "clientId": "client-app",
                 "realm": "secure-app",
                 "resource": "client-app",
                 "ssl-required": "external",


### PR DESCRIPTION
## Motivation

`clientId` is no longer provided by the Mobile CLI. So we shouldn't have it in our example app either.

## Description

Currently we are including the `clientId` in the `mobile-services.json` configuration file for our example app. However, the changes in https://github.com/aerogearcatalog/keycloak-apb/pull/66 means that the `clientId` no longer exists.

This change removes the `clientId` from the example application.

## Progress

- [x] Remove `clientId` from `mobile-services.json`
