### PR TITLE
Security metrics to contain default metrics

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -2,6 +2,7 @@ package org.aerogear.mobile.security;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.aerogear.mobile.core.metrics.MetricsService;
@@ -14,7 +15,8 @@ import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
 class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
 
     private final MetricsService metricsService;
-    private final List<SecurityCheckResult> metricResults = new ArrayList<>();
+    private final List<SecurityCheckResult> metricResults =
+                    Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Builds the object.
@@ -26,12 +28,12 @@ class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
     }
 
     @Override
-    public synchronized void onExecuted(SecurityCheckResult result) {
+    public void onExecuted(SecurityCheckResult result) {
         metricResults.add(result);
     }
 
     @Override
-    public synchronized void onComplete() {
+    public void onComplete() {
         metricsService.publish(SecurityService.SECURITY_METRICS_EVENT_TYPE,
                         new SecurityCheckResultMetric(metricResults));
     }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -32,6 +32,7 @@ class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
 
     @Override
     public synchronized void onComplete() {
-        metricsService.publish(new SecurityCheckResultMetric(metricResults));
+        metricsService.publish(SecurityService.SECURITY_METRICS_EVENT_TYPE,
+            new SecurityCheckResultMetric(metricResults));
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -33,6 +33,6 @@ class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
     @Override
     public synchronized void onComplete() {
         metricsService.publish(SecurityService.SECURITY_METRICS_EVENT_TYPE,
-            new SecurityCheckResultMetric(metricResults));
+                        new SecurityCheckResultMetric(metricResults));
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -22,6 +22,7 @@ import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
  */
 public class SecurityService implements ServiceModule {
 
+    public static final String SECURITY_METRICS_EVENT_TYPE = "security";
     private final static String TYPE = "security";
 
     private MobileCore core;
@@ -132,7 +133,8 @@ public class SecurityService implements ServiceModule {
     public SecurityCheckResult checkAndSendMetric(final SecurityCheck securityCheck,
                     @NonNull final MetricsService metricsService) {
         final SecurityCheckResult result = check(securityCheck);
-        nonNull(metricsService, "metricsService").publish(new SecurityCheckResultMetric(result));
+        nonNull(metricsService, "metricsService").publish(SECURITY_METRICS_EVENT_TYPE,
+                new SecurityCheckResultMetric(result));
         return result;
     }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -22,8 +22,9 @@ import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
  */
 public class SecurityService implements ServiceModule {
 
-    public static final String SECURITY_METRICS_EVENT_TYPE = "security";
-    private final static String TYPE = "security";
+    static final String SECURITY_METRICS_EVENT_TYPE = "security";
+
+    private static final String TYPE = "security";
 
     private MobileCore core;
 

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -134,7 +134,7 @@ public class SecurityService implements ServiceModule {
                     @NonNull final MetricsService metricsService) {
         final SecurityCheckResult result = check(securityCheck);
         nonNull(metricsService, "metricsService").publish(SECURITY_METRICS_EVENT_TYPE,
-                new SecurityCheckResultMetric(result));
+                        new SecurityCheckResultMetric(result));
         return result;
     }
 }

--- a/auth/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
@@ -3,6 +3,7 @@ package org.aerogear.mobile.security;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,7 +58,7 @@ public class SecurityCheckExecutorTest {
         SecurityCheckExecutor.Builder.newSyncExecutor(context).withSecurityCheck(securityCheckType)
                         .withMetricsService(metricsService).build().execute();
 
-        verify(metricsService, times(1)).publish(any());
+        verify(metricsService, times(1)).publish(eq("security"), any());
     }
 
     @Test
@@ -101,7 +102,7 @@ public class SecurityCheckExecutorTest {
         ExecutorService executorService = (new AppExecutors()).networkThread();
         executorService.submit(() -> {
             try {
-                verify(metricsService, times(1)).publish(any());
+                verify(metricsService, times(1)).publish(eq("security"), any());
             } finally {
                 latch.countDown();
             }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
@@ -10,9 +10,10 @@ public interface MetricsPublisher {
     /**
      * Allows to publish metrics to external source
      *
+     * @param type type of the enclosing metrics event
      * @param metrics a array of metrics objects to publish
      * @param callback callback of the publication
      */
-    void publish(@NonNull final Metrics[] metrics, @Nullable final Callback callback);
+    void publish(@NonNull String type, @NonNull final Metrics[] metrics, @Nullable final Callback callback);
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
@@ -36,7 +36,7 @@ public abstract class MetricsPublisher {
      * @param metrics metrics
      * @return a JSONObject
      */
-    protected JSONObject parseMetrics(final String type, final Metrics[] metrics) {
+    protected JSONObject createMetricsJSONObject(final String type, final Metrics[] metrics) {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
@@ -14,6 +14,7 @@ public interface MetricsPublisher {
      * @param metrics a array of metrics objects to publish
      * @param callback callback of the publication
      */
-    void publish(@NonNull String type, @NonNull final Metrics[] metrics, @Nullable final Callback callback);
+    void publish(@NonNull String type, @NonNull final Metrics[] metrics,
+                    @Nullable final Callback callback);
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
@@ -1,11 +1,76 @@
 package org.aerogear.mobile.core.metrics;
 
+import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.aerogear.mobile.core.Callback;
+import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.logging.Logger;
+import org.aerogear.mobile.core.metrics.impl.AppMetrics;
+import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
+import org.aerogear.mobile.core.utils.ClientIdGenerator;
 
-public interface MetricsPublisher {
+public abstract class MetricsPublisher {
+
+    private static final Logger LOGGER = MobileCore.getLogger();
+
+    private final Context context;
+    private final Metrics[] defaultMetrics;
+
+    public MetricsPublisher(final Context context) {
+        this.context = context;
+
+        defaultMetrics = new Metrics[] {new AppMetrics(context), new DeviceMetrics()};
+    }
+
+    /**
+     * Parse metrics into a JSONObject and add communs information for all metrics requests:
+     *
+     * - clientId - timestamp - type - app - device
+     *
+     * @param type the type of metrics
+     * @param metrics metrics
+     * @return a JSONObject
+     */
+    protected JSONObject parseMetrics(final String type, final Metrics[] metrics) {
+        nonNull(type, "type");
+        nonNull(metrics, "metrics");
+
+        final JSONObject json = new JSONObject();
+
+        try {
+
+            json.put("clientId", ClientIdGenerator.getOrCreateClientId(context));
+            json.put("timestamp", System.currentTimeMillis());
+            json.put("type", type);
+
+            final JSONObject data = new JSONObject();
+
+            // first put the default metrics (app and device info)
+            for (final Metrics m : defaultMetrics) {
+                data.put(m.identifier(), m.data());
+            }
+
+            // then put the specific ones
+            for (final Metrics m : metrics) {
+                data.put(m.identifier(), m.data());
+            }
+
+            json.put("data", data);
+
+        } catch (JSONException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+
+        return json;
+
+    }
 
     /**
      * Allows to publish metrics to external source
@@ -14,7 +79,7 @@ public interface MetricsPublisher {
      * @param metrics a array of metrics objects to publish
      * @param callback callback of the publication
      */
-    void publish(@NonNull String type, @NonNull final Metrics[] metrics,
+    protected abstract void publish(@NonNull String type, @NonNull final Metrics[] metrics,
                     @Nullable final Callback callback);
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsPublisher.java
@@ -30,9 +30,7 @@ public abstract class MetricsPublisher {
     }
 
     /**
-     * Parse metrics into a JSONObject and add communs information for all metrics requests:
-     *
-     * - clientId - timestamp - type - app - device
+     * Parse metrics into a JSONObject and add common information for all metrics requests:
      *
      * @param type the type of metrics
      * @param metrics metrics

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -87,7 +87,8 @@ public class MetricsService implements ServiceModule {
      * @param metrics Metrics to send
      * @param callback callback of the publication
      */
-    public void publish(@NonNull String type, @NonNull final Metrics[] metrics, final Callback callback) {
+    public void publish(@NonNull String type, @NonNull final Metrics[] metrics,
+                    final Callback callback) {
         if (publisher == null) {
             throw new IllegalStateException(
                             "Make sure you have called configure or get this instance from MobileCore.getInstance()");

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -41,7 +41,7 @@ public class MetricsService implements ServiceModule {
 
         final String metricsUrl = serviceConfiguration.getUrl();
         if (metricsUrl == null) {
-            publisher = new LoggerMetricsPublisher(MobileCore.getLogger(), core.getContext());
+            publisher = new LoggerMetricsPublisher(core.getContext());
         } else {
             publisher = new NetworkMetricsPublisher(core.getContext(),
                             core.getHttpLayer().newRequest(), metricsUrl);

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -15,6 +15,8 @@ public class MetricsService implements ServiceModule {
 
     private static final String INIT_METRICS_TYPE = "init";
 
+    private static final Metrics[] EMPTY_METRICS = new Metrics[0];
+
     private MetricsPublisher publisher;
 
     public MetricsPublisher getPublisher() {
@@ -58,7 +60,9 @@ public class MetricsService implements ServiceModule {
      * Send default metrics
      */
     public void sendAppAndDeviceMetrics() {
-        this.publish(INIT_METRICS_TYPE, new Metrics[0], null);
+        // as app and device metrics are added by the publisher
+        // to the payload, we only pass empty metrics to publisher
+        this.publish(INIT_METRICS_TYPE, EMPTY_METRICS, null);
     }
 
     /**
@@ -67,7 +71,9 @@ public class MetricsService implements ServiceModule {
      * @param callback callback of the publication
      */
     public void sendAppAndDeviceMetrics(final Callback callback) {
-        this.publish(INIT_METRICS_TYPE, new Metrics[0], callback);
+        // as app and device metrics are added by the publisher
+        // to the payload, we only pass empty metrics to publisher
+        this.publish(INIT_METRICS_TYPE, EMPTY_METRICS, callback);
     }
 
     /**
@@ -93,9 +99,8 @@ public class MetricsService implements ServiceModule {
             throw new IllegalStateException(
                             "Make sure you have called configure or get this instance from MobileCore.getInstance()");
         }
-        nonNull(type, "type");
-        nonNull(metrics, "metrics");
-        publisher.publish(type, metrics, callback);
+
+        publisher.publish(nonNull(type, "type"), nonNull(metrics, "metrics"), callback);
     }
 
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/impl/DeviceMetrics.java
@@ -3,7 +3,6 @@ package org.aerogear.mobile.core.metrics.impl;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.content.Context;
 import android.os.Build;
 
 import org.aerogear.mobile.core.MobileCore;
@@ -18,7 +17,7 @@ public class DeviceMetrics implements Metrics<JSONObject> {
     private final String platform;
     private final String platformVersion;
 
-    public DeviceMetrics(final Context context) {
+    public DeviceMetrics() {
         this.platform = "android";
         this.platformVersion = String.valueOf(Build.VERSION.SDK_INT);
     }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
@@ -31,7 +31,7 @@ public final class LoggerMetricsPublisher extends MetricsPublisher {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
 
-        final JSONObject json = parseMetrics(type, metrics);
+        final JSONObject json = createMetricsJSONObject(type, metrics);
 
         LOGGER.debug(json.toString());
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
@@ -2,28 +2,27 @@ package org.aerogear.mobile.core.metrics.publisher;
 
 import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
+import org.json.JSONObject;
+
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.aerogear.mobile.core.Callback;
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.core.metrics.MetricsPublisher;
-import org.aerogear.mobile.core.metrics.impl.AppMetrics;
-import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
 
 /**
  * All metrics data will be logged only
  */
-public final class LoggerMetricsPublisher implements MetricsPublisher {
+public final class LoggerMetricsPublisher extends MetricsPublisher {
 
-    private final Logger logger;
-    private Metrics[] defaultMetrics;
+    private static final Logger LOGGER = MobileCore.getLogger();
 
-    public LoggerMetricsPublisher(final Logger logger, Context context) {
-        this.logger = logger;
-        this.defaultMetrics = new Metrics[] {new AppMetrics(context), new DeviceMetrics(context)};
+    public LoggerMetricsPublisher(Context context) {
+        super(context);
     }
 
     @Override
@@ -31,15 +30,11 @@ public final class LoggerMetricsPublisher implements MetricsPublisher {
                     @Nullable final Callback callback) {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
-        logger.debug("Metrics: " + type);
-        // first log the default metrics (app and device info)
-        for (final Metrics m : defaultMetrics) {
-            logger.debug("-> [" + m.identifier() + "]:" + m.data());
-        }
-        // then log the specific metrics
-        for (final Metrics m : metrics) {
-            logger.debug("-> [" + m.identifier() + "]:" + m.data());
-        }
+
+        final JSONObject json = parseMetrics(type, metrics);
+
+        LOGGER.debug(json.toString());
+
         if (callback != null) {
             callback.onSuccess();
         }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
@@ -34,11 +34,11 @@ public final class LoggerMetricsPublisher implements MetricsPublisher {
         logger.debug("Metrics: " + type);
         // first log the default metrics (app and device info)
         for (final Metrics m : defaultMetrics) {
-            logger.debug("-> [" + m.identifier() + "]:" + m.data().toString());
+            logger.debug("-> [" + m.identifier() + "]:" + m.data());
         }
         // then log the specific metrics
         for (final Metrics m : metrics) {
-            logger.debug("-> [" + m.identifier() + "]:" + m.data().toString());
+            logger.debug("-> [" + m.identifier() + "]:" + m.data());
         }
         if (callback != null) {
             callback.onSuccess();

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
@@ -27,7 +27,8 @@ public final class LoggerMetricsPublisher implements MetricsPublisher {
     }
 
     @Override
-    public void publish(@NonNull String type, @NonNull final Metrics[] metrics, @Nullable final Callback callback) {
+    public void publish(@NonNull String type, @NonNull final Metrics[] metrics,
+                    @Nullable final Callback callback) {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
         logger.debug("Metrics: " + type);

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/LoggerMetricsPublisher.java
@@ -2,6 +2,7 @@ package org.aerogear.mobile.core.metrics.publisher;
 
 import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -9,6 +10,8 @@ import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.core.metrics.MetricsPublisher;
+import org.aerogear.mobile.core.metrics.impl.AppMetrics;
+import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
 
 /**
  * All metrics data will be logged only
@@ -16,16 +19,25 @@ import org.aerogear.mobile.core.metrics.MetricsPublisher;
 public final class LoggerMetricsPublisher implements MetricsPublisher {
 
     private final Logger logger;
+    private Metrics[] defaultMetrics;
 
-    public LoggerMetricsPublisher(final Logger logger) {
+    public LoggerMetricsPublisher(final Logger logger, Context context) {
         this.logger = logger;
+        this.defaultMetrics = new Metrics[] {new AppMetrics(context), new DeviceMetrics(context)};
     }
 
     @Override
-    public void publish(@NonNull final Metrics[] metrics, @Nullable final Callback callback) {
+    public void publish(@NonNull String type, @NonNull final Metrics[] metrics, @Nullable final Callback callback) {
+        nonNull(type, "type");
         nonNull(metrics, "metrics");
+        logger.debug("Metrics: " + type);
+        // first log the default metrics (app and device info)
+        for (final Metrics m : defaultMetrics) {
+            logger.debug("-> [" + m.identifier() + "]:" + m.data().toString());
+        }
+        // then log the specific metrics
         for (final Metrics m : metrics) {
-            logger.debug("Metrics -> [" + m.identifier() + "]:" + m.data().toString());
+            logger.debug("-> [" + m.identifier() + "]:" + m.data().toString());
         }
         if (callback != null) {
             callback.onSuccess();

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -32,7 +32,8 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
     private final String url;
     private final Metrics[] defaultMetrics;
 
-    public NetworkMetricsPublisher(final Context context, final HttpRequest httpRequest, final String url) {
+    public NetworkMetricsPublisher(final Context context, final HttpRequest httpRequest,
+                    final String url) {
         this.context = context;
         this.httpRequest = httpRequest;
         this.url = url;
@@ -40,7 +41,8 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
     }
 
     @Override
-    public void publish(@NonNull String type, @NonNull final Metrics[] metrics, @Nullable final Callback callback) {
+    public void publish(@NonNull String type, @NonNull final Metrics[] metrics,
+                    @Nullable final Callback callback) {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
 

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -2,7 +2,6 @@ package org.aerogear.mobile.core.metrics.publisher;
 
 import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.content.Context;
@@ -16,28 +15,23 @@ import org.aerogear.mobile.core.http.HttpResponse;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.core.metrics.MetricsPublisher;
-import org.aerogear.mobile.core.metrics.impl.AppMetrics;
-import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
-import org.aerogear.mobile.core.utils.ClientIdGenerator;
 
 /**
  * Sends metrics data to the backend using the configuration in JSON config file
  */
-public class NetworkMetricsPublisher implements MetricsPublisher {
+public final class NetworkMetricsPublisher extends MetricsPublisher {
 
-    public static final Logger LOGGER = MobileCore.getLogger();
+    private static final Logger LOGGER = MobileCore.getLogger();
 
-    private final Context context;
     private final HttpRequest httpRequest;
     private final String url;
-    private final Metrics[] defaultMetrics;
 
     public NetworkMetricsPublisher(final Context context, final HttpRequest httpRequest,
                     final String url) {
-        this.context = context;
+        super(context);
+
         this.httpRequest = httpRequest;
         this.url = url;
-        this.defaultMetrics = new Metrics[] {new AppMetrics(context), new DeviceMetrics(context)};
     }
 
     @Override
@@ -46,46 +40,24 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
 
-        try {
-            final JSONObject json = new JSONObject();
+        final JSONObject json = parseMetrics(type, metrics);
 
-            json.put("clientId", ClientIdGenerator.getOrCreateClientId(context));
-            json.put("timestamp", System.currentTimeMillis());
-            json.put("type", type);
+        httpRequest.post(url, json.toString().getBytes());
 
-            final JSONObject data = new JSONObject();
+        LOGGER.debug("Sending metrics");
 
-            // first put the default metrics (app and device info)
-            for (final Metrics m : defaultMetrics) {
-                data.put(m.identifier(), m.data());
+        final HttpResponse httpResponse = httpRequest.execute();
+        httpResponse.onSuccess(() -> {
+            if (callback != null) {
+                callback.onSuccess();
             }
-
-            // then put the specific ones
-            for (final Metrics m : metrics) {
-                data.put(m.identifier(), m.data());
+        }).onError(() -> {
+            if (callback != null) {
+                callback.onError(httpResponse.getError());
+            } else {
+                LOGGER.error(httpResponse.getError().getMessage());
             }
+        });
 
-            json.put("data", data);
-
-            httpRequest.post(url, json.toString().getBytes());
-
-            LOGGER.debug("Sending metrics");
-
-            final HttpResponse httpResponse = httpRequest.execute();
-            httpResponse.onSuccess(() -> {
-                if (callback != null) {
-                    callback.onSuccess();
-                }
-            }).onError(() -> {
-                if (callback != null) {
-                    callback.onError(httpResponse.getError());
-                } else {
-                    LOGGER.error(httpResponse.getError().getMessage());
-                }
-            });
-
-        } catch (JSONException e) {
-            LOGGER.error(e.getMessage(), e);
-        }
     }
 }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -16,6 +16,8 @@ import org.aerogear.mobile.core.http.HttpResponse;
 import org.aerogear.mobile.core.logging.Logger;
 import org.aerogear.mobile.core.metrics.Metrics;
 import org.aerogear.mobile.core.metrics.MetricsPublisher;
+import org.aerogear.mobile.core.metrics.impl.AppMetrics;
+import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
 import org.aerogear.mobile.core.utils.ClientIdGenerator;
 
 /**
@@ -28,16 +30,18 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
     private final Context context;
     private final HttpRequest httpRequest;
     private final String url;
+    private final Metrics[] defaultMetrics;
 
-    public NetworkMetricsPublisher(final Context context, final HttpRequest httpRequest,
-                    final String url) {
+    public NetworkMetricsPublisher(final Context context, final HttpRequest httpRequest, final String url) {
         this.context = context;
         this.httpRequest = httpRequest;
         this.url = url;
+        this.defaultMetrics = new Metrics[] {new AppMetrics(context), new DeviceMetrics(context)};
     }
 
     @Override
-    public void publish(@NonNull final Metrics[] metrics, @Nullable final Callback callback) {
+    public void publish(@NonNull String type, @NonNull final Metrics[] metrics, @Nullable final Callback callback) {
+        nonNull(type, "type");
         nonNull(metrics, "metrics");
 
         try {
@@ -45,8 +49,16 @@ public class NetworkMetricsPublisher implements MetricsPublisher {
 
             json.put("clientId", ClientIdGenerator.getOrCreateClientId(context));
             json.put("timestamp", System.currentTimeMillis());
+            json.put("type", type);
 
             final JSONObject data = new JSONObject();
+
+            // first put the default metrics (app and device info)
+            for (final Metrics m : defaultMetrics) {
+                data.put(m.identifier(), m.data());
+            }
+
+            // then put the specific ones
             for (final Metrics m : metrics) {
                 data.put(m.identifier(), m.data());
             }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -40,7 +40,7 @@ public final class NetworkMetricsPublisher extends MetricsPublisher {
         nonNull(type, "type");
         nonNull(metrics, "metrics");
 
-        final JSONObject json = parseMetrics(type, metrics);
+        final JSONObject json = createMetricsJSONObject(type, metrics);
 
         httpRequest.post(url, json.toString().getBytes());
 

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -81,7 +81,7 @@ public class MetricsServiceIntegrationTest {
             }
         };
 
-        metricsService.publish(new Metrics[] {metrics}, testCallback);
+        metricsService.publish("init", new Metrics[] {metrics}, testCallback);
         latch.await(10, TimeUnit.SECONDS);
 
         assertNull(error);

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
@@ -68,7 +68,7 @@ public class MetricsServiceTest {
 
     @Test(expected = IllegalStateException.class)
     public void sendingMetricsWithoutConfigureService() {
-        metricsService.publish(new DummyMetrics());
+        metricsService.publish("init", new DummyMetrics());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class MetricsServiceTest {
         };
         metricsService.sendAppAndDeviceMetrics(testCallback);
 
-        metricsService.publish(new DummyMetrics[] {new DummyMetrics()}, testCallback);
+        metricsService.publish("init", new DummyMetrics[] {new DummyMetrics()}, testCallback);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class MetricsServiceTest {
         };
 
         metricsService.sendAppAndDeviceMetrics(testCallback);
-        metricsService.publish(new DummyMetrics[] {new DummyMetrics()}, testCallback);
+        metricsService.publish("init", new DummyMetrics[] {new DummyMetrics()}, testCallback);
     }
 
     public static class DummyMetrics implements Metrics<Map<String, String>> {

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/DeviceMetricsTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/impl/DeviceMetricsTest.java
@@ -8,9 +8,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
-import android.app.Application;
 import android.support.test.filters.SmallTest;
 
 import org.aerogear.mobile.core.metrics.impl.DeviceMetrics;
@@ -21,17 +19,13 @@ public class DeviceMetricsTest {
 
     @Test
     public void testType() {
-        Application context = RuntimeEnvironment.application;
-
-        DeviceMetrics deviceMetrics = new DeviceMetrics(context);
+        DeviceMetrics deviceMetrics = new DeviceMetrics();
         assertEquals("device", deviceMetrics.identifier());
     }
 
     @Test
     public void testData() throws JSONException {
-        Application context = RuntimeEnvironment.application;
-
-        DeviceMetrics deviceMetrics = new DeviceMetrics(context);
+        DeviceMetrics deviceMetrics = new DeviceMetrics();
         JSONObject result = deviceMetrics.data();
 
         assertNotNull(result.getString("platform"));

--- a/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
@@ -2,7 +2,6 @@ package org.aerogear.mobile.example;
 
 import android.app.Application;
 
-import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.MetricsService;
 
@@ -18,12 +17,8 @@ public class ExampleApplication extends Application {
         mobileCore = MobileCore.init(this);
         metricsService = mobileCore.getInstance(MetricsService.class);
 
-        metricsService.sendAppAndDeviceMetrics(new Callback() {
-            @Override
-            public void onError(Throwable error) {
-                MobileCore.getLogger().error(error.getMessage());
-            }
-        });
+        metricsService.sendAppAndDeviceMetrics(
+                        error -> MobileCore.getLogger().error(error.getMessage()));
     }
 
     @Override


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AGDROID-801

## Description

Depends on https://github.com/aerogear/aerogear-android-sdk/pull/179

2 changes:
- Sends event types ("init" or "security") with metrics
- Security events now contains app and device info