### PR TITLE
Check if push categories follow the Firebase topic name format

### DIFF
--- a/example/src/main/assets/mobile-services.json
+++ b/example/src/main/assets/mobile-services.json
@@ -28,12 +28,12 @@
         {
             "id": "push",
             "name": "push",
-            "url": "https://testing.zeta.feedhenry.com/api/v2/ag-push/",
+            "url": "https://ups-dm-myproject-1.193b.starter-ca-central-1.openshiftapps.com/",
             "type": "push",
             "config": {
                 "android": {
-                    "variantId": "8d35bdcb-3261-43d9-b61e-31f618cc48e2",
-                    "variantSecret": "0707927e-7851-4ead-848e-991b943ea4ea",
+                    "variantId": "9351f86d-9531-4ba3-beac-b73dc3c8764b",
+                    "variantSecret": "22784d6d-9526-4826-bbed-b18e977fc38c",
                     "senderId": "56938872708"
                 }
             }

--- a/push/build.gradle
+++ b/push/build.gradle
@@ -28,4 +28,9 @@ dependencies {
     implementation project(path: ":core")
 
     implementation "com.google.firebase:firebase-messaging:${project.ext.firebase_version}"
+
+    testImplementation "junit:junit:${project.ext.junit_version}"
+    testImplementation "com.android.support.test:runner:${project.ext.android_support_test_runner_version}"
+    testImplementation "com.android.support.test:rules:${project.ext.android_support_test_rules_version}"
+
 }

--- a/push/src/main/java/org/aerogear/mobile/push/MessageHandler.java
+++ b/push/src/main/java/org/aerogear/mobile/push/MessageHandler.java
@@ -9,6 +9,7 @@ public interface MessageHandler {
     /**
      * Invoked when server delivered a message to the device.
      *
+     * @param context The application context
      * @param message A map containing the submitted key/value pairs
      */
     public void onMessage(Context context, Map<String, String> message);

--- a/push/src/main/java/org/aerogear/mobile/push/UnifiedPushConfig.java
+++ b/push/src/main/java/org/aerogear/mobile/push/UnifiedPushConfig.java
@@ -6,6 +6,13 @@ import java.util.List;
 
 public final class UnifiedPushConfig {
 
+    /**
+     * Topics in GCM must conform to this pattern. See :
+     * https://developers.google.com/android/reference/com/google/android/gms/gcm/GcmPubSub#unsubscribe(java.lang.String,
+     * java.lang.String)
+     */
+    private static final String FCM_TOPIC_PATTERN = "[a-zA-Z0-9-_.~%]{1,900}";
+
     private String alias;
     private List<String> categories = Collections.emptyList();
 
@@ -22,7 +29,29 @@ public final class UnifiedPushConfig {
     }
 
     public void setCategories(List<String> categories) {
+        validateCategories(categories);
         this.categories = new ArrayList<>(categories);
+    }
+
+
+    /**
+     * Validates categories against Google's pattern.
+     *
+     * @param categories a group of Strings each will be validated.
+     * @throws IllegalArgumentException if a category fails to match [a-zA-Z0-9-_.~%]{1,900}
+     */
+    private static void validateCategories(List<String> categories) {
+
+        if (categories == null) {
+            return;
+        }
+
+        for (String category : categories) {
+            if (!category.matches(FCM_TOPIC_PATTERN)) {
+                throw new IllegalArgumentException(
+                                String.format("%s does not match %s", category, FCM_TOPIC_PATTERN));
+            }
+        }
     }
 
 }

--- a/push/src/main/java/org/aerogear/mobile/push/UnifiedPushConfig.java
+++ b/push/src/main/java/org/aerogear/mobile/push/UnifiedPushConfig.java
@@ -1,5 +1,7 @@
 package org.aerogear.mobile.push;
 
+import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -7,9 +9,8 @@ import java.util.List;
 public final class UnifiedPushConfig {
 
     /**
-     * Topics in GCM must conform to this pattern. See :
-     * https://developers.google.com/android/reference/com/google/android/gms/gcm/GcmPubSub#unsubscribe(java.lang.String,
-     * java.lang.String)
+     * Topics in Firebase must conform to this pattern. See:
+     * https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging#subscribeToTopic(java.lang.String)
      */
     private static final String FCM_TOPIC_PATTERN = "[a-zA-Z0-9-_.~%]{1,900}";
 
@@ -29,10 +30,10 @@ public final class UnifiedPushConfig {
     }
 
     public void setCategories(List<String> categories) {
+        nonNull(categories, "categories");
         validateCategories(categories);
         this.categories = new ArrayList<>(categories);
     }
-
 
     /**
      * Validates categories against Google's pattern.
@@ -41,11 +42,6 @@ public final class UnifiedPushConfig {
      * @throws IllegalArgumentException if a category fails to match [a-zA-Z0-9-_.~%]{1,900}
      */
     private static void validateCategories(List<String> categories) {
-
-        if (categories == null) {
-            return;
-        }
-
         for (String category : categories) {
             if (!category.matches(FCM_TOPIC_PATTERN)) {
                 throw new IllegalArgumentException(

--- a/push/src/test/java/org/aerogear/mobile/push/UnitTestSuite.java
+++ b/push/src/test/java/org/aerogear/mobile/push/UnitTestSuite.java
@@ -1,0 +1,14 @@
+package org.aerogear.mobile.push;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import org.aerogear.mobile.push.unit.UnifiedPushConfigTest;
+
+/**
+ * Suite containing all unit tests in core
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({UnifiedPushConfigTest.class})
+public class UnitTestSuite {
+}

--- a/push/src/test/java/org/aerogear/mobile/push/unit/UnifiedPushConfigTest.java
+++ b/push/src/test/java/org/aerogear/mobile/push/unit/UnifiedPushConfigTest.java
@@ -1,0 +1,62 @@
+package org.aerogear.mobile.push.unit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.aerogear.mobile.push.UnifiedPushConfig;
+
+public class UnifiedPushConfigTest {
+
+    @Test
+    public void testAlias() {
+        String alias = "Push";
+
+        UnifiedPushConfig unifiedPushConfig = new UnifiedPushConfig();
+        unifiedPushConfig.setAlias(alias);
+
+        assertEquals(alias, unifiedPushConfig.getAlias());
+        assertSame(alias, unifiedPushConfig.getAlias());
+    }
+
+    @Test
+    public void testCategoriesSeflDefenceCopy() {
+        List<String> categories = new ArrayList<>();
+        categories.add("AeroGear");
+
+        UnifiedPushConfig unifiedPushConfig = new UnifiedPushConfig();
+        unifiedPushConfig.setCategories(categories);
+
+        assertEquals(1, unifiedPushConfig.getCategories().size());
+        assertNotSame(categories, unifiedPushConfig.getCategories());
+    }
+
+    @Test
+    public void testCategoriesWithValidNames() {
+        List<String> categories = new ArrayList<>();
+        categories.add("AeroGear");
+
+        UnifiedPushConfig unifiedPushConfig = new UnifiedPushConfig();
+        unifiedPushConfig.setCategories(categories);
+
+        assertEquals(1, unifiedPushConfig.getCategories().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCategoriesWithInvalidNames() {
+        List<String> categories = new ArrayList<>();
+        categories.add("Red Hat");
+
+        UnifiedPushConfig unifiedPushConfig = new UnifiedPushConfig();
+        unifiedPushConfig.setCategories(categories);
+
+        fail("It should raise an IllegalArgumentException");
+    }
+
+}

--- a/push/src/test/java/org/aerogear/mobile/push/unit/UnifiedPushConfigTest.java
+++ b/push/src/test/java/org/aerogear/mobile/push/unit/UnifiedPushConfigTest.java
@@ -25,6 +25,14 @@ public class UnifiedPushConfigTest {
         assertSame(alias, unifiedPushConfig.getAlias());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullableCheckForCategories() {
+        UnifiedPushConfig unifiedPushConfig = new UnifiedPushConfig();
+        unifiedPushConfig.setCategories(null);
+
+        fail("It should raise an IllegalArgumentException");
+    }
+
     @Test
     public void testCategoriesSeflDefenceCopy() {
         List<String> categories = new ArrayList<>();


### PR DESCRIPTION
Since we are creating a Firebase topic for each category, the categories name needs to follow the [Firebase topic name rules](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging.html#subscribeToTopic(java.lang.String)) 

Related issues:
* [AGDROID-804](https://issues.jboss.org/browse/AGDROID-804)