### PR TITLE
Add warning dialog to example app

### DIFF
--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -1,21 +1,15 @@
 package org.aerogear.mobile.example.ui;
 
 import android.app.AlertDialog;
-import android.app.Dialog;
-import android.content.DialogInterface;
-import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.aerogear.mobile.auth.AuthService;
 import org.aerogear.mobile.auth.authenticator.DefaultAuthenticateOptions;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.example.R;
-import org.aerogear.mobile.security.SecurityService;
 
 import butterknife.BindView;
 import butterknife.OnClick;

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -61,8 +61,8 @@ public class AuthFragment extends BaseFragment {
 
     public void messageDialog(final String title, final String message) {
         activity.runOnUiThread(() -> {
-            AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
-            certPinningErrorBuilder.setTitle(title).setMessage(message).show().create();
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(activity);
+            dialogBuilder.setTitle(title).setMessage(message).show().create();
         });
     }
 }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -41,7 +41,7 @@ public class AuthFragment extends BaseFragment {
     public void doLogin() {
         AuthService authService = ((MainActivity) getActivity()).getAuthService();
         DefaultAuthenticateOptions authOptions =
-            new DefaultAuthenticateOptions(this.getActivity(), LOGIN_RESULT_CODE);
+                        new DefaultAuthenticateOptions(this.getActivity(), LOGIN_RESULT_CODE);
         authService.login(authOptions, new Callback<UserPrincipal>() {
             @Override
             public void onSuccess(UserPrincipal models) {
@@ -65,7 +65,8 @@ public class AuthFragment extends BaseFragment {
             @Override
             public void run() {
                 AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
-                certPinningErrorBuilder.setTitle("Failed to Authenticate").setMessage(error).show().create();
+                certPinningErrorBuilder.setTitle("Failed to Authenticate").setMessage(error).show()
+                                .create();
             }
         });
     }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -44,28 +44,27 @@ public class AuthFragment extends BaseFragment {
                         new DefaultAuthenticateOptions(this.getActivity(), LOGIN_RESULT_CODE);
         authService.login(authOptions, new Callback<UserPrincipal>() {
             @Override
-            public void onSuccess(UserPrincipal models) {
+            public void onSuccess(final UserPrincipal models) {
                 // user logged in, continue on..
-                Log.i(TAG, "user logged in " + models.toString());
+                Log.i(TAG, "user logged in " + models);
                 ((MainActivity) getActivity()).navigateToAuthDetailsView(models);
             }
 
             @Override
-            public void onError(Throwable error) {
+            public void onError(final Throwable error) {
                 // there is an error during the login
                 Log.e(TAG, "login failed due to error " + error.getLocalizedMessage());
-                failureDialog(error.getLocalizedMessage());
+                messageDialog("Failed to Authenticate" , error.getLocalizedMessage());
             }
         });
     }
 
-    public void failureDialog(String e) {
-        String error = e;
+    public void messageDialog(final String title, final String message) {
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
-                certPinningErrorBuilder.setTitle("Failed to Authenticate").setMessage(error).show()
+                certPinningErrorBuilder.setTitle(title).setMessage(message).show()
                                 .create();
             }
         });

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -54,7 +54,7 @@ public class AuthFragment extends BaseFragment {
             public void onError(final Throwable error) {
                 // there is an error during the login
                 Log.e(TAG, "login failed due to error " + error.getLocalizedMessage());
-                messageDialog("Failed to Authenticate" , error.getLocalizedMessage());
+                messageDialog("Failed to Authenticate", error.getLocalizedMessage());
             }
         });
     }
@@ -64,8 +64,7 @@ public class AuthFragment extends BaseFragment {
             @Override
             public void run() {
                 AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
-                certPinningErrorBuilder.setTitle(title).setMessage(message).show()
-                                .create();
+                certPinningErrorBuilder.setTitle(title).setMessage(message).show().create();
             }
         });
     }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -1,14 +1,21 @@
 package org.aerogear.mobile.example.ui;
 
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.aerogear.mobile.auth.AuthService;
 import org.aerogear.mobile.auth.authenticator.DefaultAuthenticateOptions;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.example.R;
+import org.aerogear.mobile.security.SecurityService;
 
 import butterknife.BindView;
 import butterknife.OnClick;
@@ -40,24 +47,32 @@ public class AuthFragment extends BaseFragment {
     public void doLogin() {
         AuthService authService = ((MainActivity) getActivity()).getAuthService();
         DefaultAuthenticateOptions authOptions =
-                        new DefaultAuthenticateOptions(this.getActivity(), LOGIN_RESULT_CODE);
-        try {
-            authService.login(authOptions, new Callback<UserPrincipal>() {
-                @Override
-                public void onSuccess(UserPrincipal models) {
-                    // user logged in, continue on..
-                    Log.i(TAG, "user logged in " + models.toString());
-                    ((MainActivity) getActivity()).navigateToAuthDetailsView(models);
-                }
+            new DefaultAuthenticateOptions(this.getActivity(), LOGIN_RESULT_CODE);
+        authService.login(authOptions, new Callback<UserPrincipal>() {
+            @Override
+            public void onSuccess(UserPrincipal models) {
+                // user logged in, continue on..
+                Log.i(TAG, "user logged in " + models.toString());
+                ((MainActivity) getActivity()).navigateToAuthDetailsView(models);
+            }
 
-                @Override
-                public void onError(Throwable error) {
-                    // there is an error during the login
-                    Log.e(TAG, "login failed due to error " + error.getLocalizedMessage());
-                }
-            });
-        } catch (IllegalStateException e) {
-            Log.e("Pinning Error", e.getMessage());
-        }
+            @Override
+            public void onError(Throwable error) {
+                // there is an error during the login
+                Log.e(TAG, "login failed due to error " + error.getLocalizedMessage());
+                failureDialog(error.getLocalizedMessage());
+            }
+        });
+    }
+
+    public void failureDialog(String e) {
+        String error = e;
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
+                certPinningErrorBuilder.setTitle("Failed to Authenticate").setMessage(error).show().create();
+            }
+        });
     }
 }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/AuthFragment.java
@@ -60,12 +60,9 @@ public class AuthFragment extends BaseFragment {
     }
 
     public void messageDialog(final String title, final String message) {
-        activity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
-                certPinningErrorBuilder.setTitle(title).setMessage(message).show().create();
-            }
+        activity.runOnUiThread(() -> {
+            AlertDialog.Builder certPinningErrorBuilder = new AlertDialog.Builder(activity);
+            certPinningErrorBuilder.setTitle(title).setMessage(message).show().create();
         });
     }
 }


### PR DESCRIPTION
## Motivation

There was an action from the scrum of scrums to add a dialog box on a certificate pinning failure while authenticating in app

## To Verify
- Edit `keycloak` hash value in `mobile-services.json`
- Proceed to Authenticate, request should fail and dialog shown.

