### PR TITLE
Add error handler to JwksManager

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/credentials/JwksManager.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/credentials/JwksManager.java
@@ -106,7 +106,10 @@ public class JwksManager {
         HttpRequest getRequest = httpModule.newRequest();
         getRequest.get(jwksUrl);
         HttpResponse response = getRequest.execute();
-        response.onComplete(() -> {
+        response.onError(() -> {
+            logger.error("fetchJwksError", response.getError().getLocalizedMessage());
+        });
+        response.onSuccess(() -> {
             JsonWebKeySet jwks = null;
             JwksException error = null;
             // this is invoked on a background thread.


### PR DESCRIPTION
## Motivation

GitHub Issue : https://github.com/aerogear/aerogear-android-sdk/issues/190

## Description

Currently on our fetchJwks method we check the status of a response with out checking for an error first.

 In issue https://github.com/aerogear/aerogear-android-sdk/issues/190 when using a local instance of keycloak if a request was made to keycloak with the wrong realm name a `NullPointerException` caused the app to crash.

## Verify PR
In order to replicate issue https://github.com/aerogear/aerogear-android-sdk/issues/190 and verify this PR
- Create local instance of keycloak
- Edit `mobile-service.json` file in example app to reflect local keycloak instance
- Add wrong `realm` name to keycloak service in `mobile-service.json`
- Proceed to auth example in app, and click Authenticate.

 