### PR TITLE
Adapt to new Keycloak service config

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/user/UserRole.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/user/UserRole.java
@@ -81,7 +81,7 @@ public class UserRole implements Serializable {
         UserRole userRole = (UserRole) role;
         if (userRole.type == RoleType.RESOURCE) { // do a check on resourceID
             return userRole.name.equals(name) && userRole.type == type
-                            && userRole.namespace == namespace;
+                            && (namespace != null ? namespace.equals(userRole.namespace) : userRole.namespace == null);
         } else {
             return userRole.name.equals(name) && userRole.type == type;
         }

--- a/auth/src/test/java/org/aerogear/mobile/auth/AuthServiceTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package org.aerogear.mobile.auth;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.junit.Assert;
@@ -44,7 +45,13 @@ public class AuthServiceTest {
     @Before
     public void setup() throws NoSuchFieldException, IllegalAccessException {
         MockitoAnnotations.initMocks(this);
-        when(serviceConfiguration.getProperty(anyString())).thenReturn("dummyvalue");
+        when(serviceConfiguration.getProperty("public_installation")).thenReturn("{\n" +
+            "    \"ssl-required\": \"external\",\n" +
+            "    \"realm\": \"dummy.project\",\n" +
+            "    \"resource\": \"dummy.resource\",\n" +
+            "    \"url\": \"dummy.url\",\n" +
+            "    \"auth-server-url\": \"dummy.auth.server.url\"\n" +
+            "}");
         when(mobileCore.getHttpLayer()).thenReturn(httpServiceModule);
         when(httpServiceModule.newRequest()).thenReturn(httpRequest);
     }

--- a/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/authenticator/OIDCAuthenticatorImplTest.java
@@ -190,10 +190,10 @@ public class OIDCAuthenticatorImplTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        when(serviceConfig.getProperty("auth-server-url"))
-                        .thenReturn("https://keycloak-server.com/auth");
-        when(serviceConfig.getProperty("realm")).thenReturn("realmId");
-        when(serviceConfig.getProperty("resource")).thenReturn("clientId");
+        when(serviceConfig.getProperty("public_installation")).thenReturn("{" +
+            "\"auth-server-url\":\"https://keycloak-server.com/auth\"," +
+            "\"realm\": \"realmId\"," +
+            "\"resource\": \"clientId\"}");
 
         when(serviceWrapper.getAuthorizationService()).thenReturn(authorizationService);
         when(serviceWrapper.getAuthState()).thenReturn(authState);

--- a/auth/src/test/java/org/aerogear/mobile/auth/utils/UserIdentityParserTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/utils/UserIdentityParserTest.java
@@ -33,9 +33,10 @@ public class UserIdentityParserTest {
     @Before
     public void setup() throws AuthenticationException {
         ServiceConfiguration serviceConfig = ServiceConfiguration.newConfiguration()
-                        .addProperty("resource", "client-app")
-                        .addProperty("auth-server-url", "test.server.url")
-                        .addProperty("realm", "test-realm").build();
+            .addProperty("public_installation", "{" +
+                "\"auth-server-url\":\"test.server.url\"," +
+                "\"realm\": \"test-realm\"," +
+                "\"resource\": \"client-app\"}").build();
         keycloakConfiguration = new KeycloakConfiguration(serviceConfig);
         credential = new OIDCCredentials() {
             @Override

--- a/core/src/test/assets/dummy-mobile-services.json
+++ b/core/src/test/assets/dummy-mobile-services.json
@@ -18,11 +18,11 @@
             "type": "keycloak",
             "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
             "config": {
-                "auth-server-url": "https://keycloak-myproject.192.168.64.74.nip.io/auth",
-                "realm": "myproject",
-                "resource": "juYAlRlhTyYYmOyszFa",
-                "ssl-required": "external",
-                "url": "https://keycloak-myproject.192.168.64.74.nip.io/auth"
+                "name": "keycloak",
+                "public_installation": "{\"ssl-required\": \"external\", \"realm\": \"myproject\", \"resource\": \"juYAlRlhTyYYmOyszFa\", \"url\": \"https://keycloak-myproject.192.168.64.74.nip.io/auth\", \"auth-server-url\": \"https://keycloak-myproject.192.168.64.74.nip.io/auth\"}",
+                "realm": "project2",
+                "type": "keycloak",
+                "uri": "https://keycloak-myproject.192.168.64.74.nip.io"
             }
         },
         {

--- a/core/src/test/assets/mobile-services.json
+++ b/core/src/test/assets/mobile-services.json
@@ -18,11 +18,11 @@
             "type": "keycloak",
             "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
             "config": {
-                "auth-server-url": "https://keycloak-myproject.192.168.64.74.nip.io/auth",
-                "realm": "myproject",
-                "resource": "juYAlRlhTyYYmOyszFa",
-                "ssl-required": "external",
-                "url": "https://keycloak-myproject.192.168.64.74.nip.io/auth"
+                "name": "keycloak",
+                "public_installation": "{\"ssl-required\": \"external\", \"realm\": \"myproject\", \"resource\": \"juYAlRlhTyYYmOyszFa\", \"url\": \"https://keycloak-myproject.192.168.64.74.nip.io/auth\", \"auth-server-url\": \"https://keycloak-myproject.192.168.64.74.nip.io/auth\"}",
+                "realm": "project2",
+                "type": "keycloak",
+                "uri": "https://keycloak-myproject.192.168.64.74.nip.io"
             }
         },
         {


### PR DESCRIPTION
Adapt to new Keycloak service config as it is changed in https://github.com/aerogearcatalog/keycloak-apb/pull/70

New sample config:

```
{
            "id": "keycloak",
            "name": "keycloak",
            "type": "keycloak",
            "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
            "config": {
                "name": "keycloak",
                "public_installation": "{\"ssl-required\": \"external\", \"realm\": \"myproject\", \"resource\": \"juYAlRlhTyYYmOyszFa\", \"url\": \"https://keycloak-myproject.192.168.64.74.nip.io/auth\", \"auth-server-url\": \"https://keycloak-myproject.192.168.64.74.nip.io/auth\"}",
                "realm": "project2",
                "type": "keycloak",
                "uri": "https://keycloak-myproject.192.168.64.74.nip.io"
            }
        },
```