### PR TITLE
Fix bg push notification

### DIFF
--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -306,6 +306,10 @@ public class PushService implements ServiceModule {
     public static void notifyHandlers(final Context context, final Map<String, String> message) {
         nonNull(context, "context");
 
+        if (defaultHandler == null) {
+            getDefaultHandler(context);
+        }
+
         if (BACKGROUND_THREAD_HANDLERS.isEmpty() && MAIN_THREAD_HANDLERS.isEmpty()
                         && defaultHandler != null) {
             new AppExecutors().singleThreadService().execute(() -> defaultHandler.onMessage(context,

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -308,7 +308,7 @@ public class PushService implements ServiceModule {
 
         if (BACKGROUND_THREAD_HANDLERS.isEmpty() && MAIN_THREAD_HANDLERS.isEmpty()
                         && defaultHandler != null) {
-            new AppExecutors().mainThread().execute(() -> defaultHandler.onMessage(context,
+            new AppExecutors().singleThreadService().execute(() -> defaultHandler.onMessage(context,
                             Collections.unmodifiableMap(message)));
         } else {
 


### PR DESCRIPTION
## Problem

When the app is killed by the user or device restarts the app will stop to receive background push notifications because it's using [mainThread AppExecutor](https://github.com/aerogear/aerogear-android-sdk/blob/master/core/src/main/java/org/aerogear/mobile/core/executor/AppExecutors.java#L61) instead of [singleThreadService AppExecutor](https://github.com/aerogear/aerogear-android-sdk/blob/master/core/src/main/java/org/aerogear/mobile/core/executor/AppExecutors.java#L69) and `DefaultHandler` will be null because the SDK only retrieve it when `configure` is called.

## How to test it

1. Go to the push screen and register the device on UPS
1. Send a message from UPS with the app in Foreground in the Push screen and you should it theListView
1. Send a message from UPS with the app in Background or in whatever screen not push one and you should see an notification on notification bar
1. Kill/close/force close the app and send a message from UPS and you should see an notification on notification bar