### PR TITLE
Avoid to refrehs push token when it does not exists yet

### DIFF
--- a/example/src/main/java/org/aerogear/mobile/example/ui/PushFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/PushFragment.java
@@ -1,6 +1,7 @@
 package org.aerogear.mobile.example.ui;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 
 import android.content.Context;
@@ -18,6 +19,7 @@ import org.aerogear.mobile.example.R;
 import org.aerogear.mobile.example.handler.NotificationBarMessageHandler;
 import org.aerogear.mobile.push.MessageHandler;
 import org.aerogear.mobile.push.PushService;
+import org.aerogear.mobile.push.UnifiedPushConfig;
 import org.aerogear.mobile.push.UnifiedPushMessage;
 
 import butterknife.BindView;
@@ -27,6 +29,9 @@ public class PushFragment extends BaseFragment implements MessageHandler {
 
     @BindView(R.id.messages)
     ListView messageList;
+
+    @BindView(R.id.refreshToken)
+    Button refreshToken;
 
     @BindView(R.id.register)
     Button register;
@@ -70,12 +75,22 @@ public class PushFragment extends BaseFragment implements MessageHandler {
         adapter.add(message.get(UnifiedPushMessage.MESSAGE));
     }
 
+    @OnClick(R.id.refreshToken)
+    void refreshToken() {
+        PushService pushService = MobileCore.getInstance().getService(PushService.class);
+        pushService.refreshToken();
+    }
+
     @OnClick(R.id.register)
     void register() {
         register.setEnabled(false);
 
+        UnifiedPushConfig unifiedPushConfig = new UnifiedPushConfig();
+        unifiedPushConfig.setAlias("AeroGear");
+        unifiedPushConfig.setCategories(Arrays.asList("Android", "Example"));
+
         PushService pushService = MobileCore.getInstance().getService(PushService.class);
-        pushService.registerDevice(new Callback() {
+        pushService.registerDevice(unifiedPushConfig, new Callback() {
             @Override
             public void onSuccess() {
                 new AppExecutors().mainThread().execute(() -> registered(true));
@@ -96,6 +111,7 @@ public class PushFragment extends BaseFragment implements MessageHandler {
 
     @OnClick(R.id.unregister)
     void unregister() {
+        refreshToken.setEnabled(false);
         unregister.setEnabled(false);
 
         PushService pushService = MobileCore.getInstance().getService(PushService.class);
@@ -108,6 +124,7 @@ public class PushFragment extends BaseFragment implements MessageHandler {
 
             @Override
             public void onError(Throwable error) {
+                refreshToken.setEnabled(false);
                 register.setEnabled(false);
                 MobileCore.getLogger().error(error.getMessage(), error);
                 new AppExecutors().mainThread().execute(() -> {
@@ -121,6 +138,7 @@ public class PushFragment extends BaseFragment implements MessageHandler {
 
     private void registered(boolean registered) {
         register.setEnabled(!registered);
+        refreshToken.setEnabled(registered);
         unregister.setEnabled(registered);
     }
 

--- a/example/src/main/res/layout/fragment_push.xml
+++ b/example/src/main/res/layout/fragment_push.xml
@@ -8,15 +8,26 @@
         android:id="@+id/messages"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/register"
+        app:layout_constraintBottom_toTopOf="@id/refreshToken"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
+        android:id="@+id/refreshToken"
+        android:layout_width="0dp"
+        android:layout_height="60dp"
+        android:text="Refresh Token"
+        android:enabled="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/register"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
         android:id="@+id/register"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
         android:text="Register"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/unregister"
@@ -25,7 +36,7 @@
     <Button
         android:id="@+id/unregister"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
         android:enabled="false"
         android:text="Unregister"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -309,10 +309,10 @@ public class PushService implements ServiceModule {
      */
     public void refreshToken() {
         JSONObject jsonObject = retrieveCache();
-        nonNull(jsonObject, "jsonObject");
-
-        this.registerDevice(jsonObject,
-                        error -> MobileCore.getLogger().error(error.getMessage(), error));
+        if (jsonObject != null) {
+            this.registerDevice(jsonObject,
+                            error -> MobileCore.getLogger().error(error.getMessage(), error));
+        }
     }
 
     /**


### PR DESCRIPTION
TL:DR Firebase is calling the [onTokenRefresh()](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceIdService#onTokenRefresh()) on the first time we call [getToken()](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#getToken()) forcing the lib to refresh a token how does not exist yet.

Related issues:

* [AGDROID-808](https://issues.jboss.org/browse/AGDROID-808)