### PR TITLE
fix: remove unneded post from metrics

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/publisher/NetworkMetricsPublisher.java
@@ -44,9 +44,6 @@ public final class NetworkMetricsPublisher extends MetricsPublisher {
 
         final JSONObject json = createMetricsJSONObject(type, metrics);
 
-        httpRequest.post(url, json.toString().getBytes());
-
-
         httpRequest.post(url, json.toString().getBytes())
                         .respondWith(new Responder<HttpResponse>() {
                             @Override


### PR DESCRIPTION
## Motivation

Metrics is now sending the same data twice. 
This is happening due to some copy paste issue that weren't caught on verification.
This PR removes second unneeded call. 