### PR TITLE
fix: use type for mobile-services

### DIFF
--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
@@ -49,7 +49,7 @@ public final class MobileCoreJsonParser {
         Map<String, ServiceConfiguration> serviceConfigs = new HashMap<>();
         for (int i = 0; i < length; i++) {
             ServiceConfiguration serviceConfig = parseConfigObject(array.getJSONObject(i));
-            serviceConfigs.put(serviceConfig.getName(), serviceConfig);
+            serviceConfigs.put(serviceConfig.getType(), serviceConfig);
         }
         return serviceConfigs;
     }


### PR DESCRIPTION
## Motivation

Use type for fetching mobile configurations instead of name. 
Name is just human readable name and it's not guaranteed to be unique.

See: https://groups.google.com/forum/#!topic/aerogear/1hxhEPBASVY 