### PR TITLE
AEROGEAR-2669 - Android SDK should query for configuration type and id

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ if ( prLabels.contains("test/integration") ) {
 
                     // Update URL for metrics in mobile-services.json file
                     servicesConfigJson.services.each {
-                        if ( it.id == "metrics" ) {
+                        if ( it.type == "metrics" ) {
                             it.url = metricsApiHost + "/metrics"
                         }
                     }

--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthService.java
@@ -221,8 +221,4 @@ public class AuthService implements ServiceModule {
         return true;
     }
 
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
+++ b/auth/src/main/java/org/aerogear/mobile/security/SecurityService.java
@@ -63,12 +63,6 @@ public class SecurityService implements ServiceModule {
     }
 
     /**
-     * Invoked when security service needs to be destroyed.
-     */
-    @Override
-    public void destroy() {}
-
-    /**
      * Retrieve a check executor that can synchronously run multiple security checks.
      *
      * @return {@link SyncSecurityCheckExecutor}

--- a/core/src/main/java/org/aerogear/mobile/core/ServiceModule.java
+++ b/core/src/main/java/org/aerogear/mobile/core/ServiceModule.java
@@ -26,10 +26,4 @@ public interface ServiceModule {
      * @return <code>true</code> if the singleThreadService configuration should be defined.
      */
     boolean requiresConfiguration();
-
-    /**
-     * Called when singleThreadService destroyed
-     */
-    void destroy();
-
 }

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreConfiguration.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreConfiguration.java
@@ -23,7 +23,7 @@ public class MobileCoreConfiguration {
     public MobileCoreConfiguration(final Map<String, ServiceConfiguration> serviceConfigsPerId,
                     final HttpsConfiguration httpsConfig) {
         this.httpsConfig = httpsConfig;
-        this.serviceConfigsPerId = serviceConfigsPerId;
+        this.serviceConfigsPerId = new HashMap<>(serviceConfigsPerId);
 
         // now, create a map of <service type, list<config>> from <service id, config> map
         serviceConfigsByType = new HashMap<>();

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreConfiguration.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreConfiguration.java
@@ -1,6 +1,9 @@
 package org.aerogear.mobile.core.configuration;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.aerogear.mobile.core.configuration.https.HttpsConfiguration;
@@ -10,12 +13,30 @@ import org.aerogear.mobile.core.configuration.https.HttpsConfiguration;
  */
 public class MobileCoreConfiguration {
     private final HttpsConfiguration httpsConfig;
-    private final Map<String, ServiceConfiguration> serviceConfig;
 
-    public MobileCoreConfiguration(final Map<String, ServiceConfiguration> serviceConfig,
+    // a map of <service id, config>
+    private final Map<String, ServiceConfiguration> serviceConfigsPerId;
+
+    // a map of <service type, list<config>> as there can be multiple configs for a service type
+    private final Map<String, List<ServiceConfiguration>> serviceConfigsByType;
+
+    public MobileCoreConfiguration(final Map<String, ServiceConfiguration> serviceConfigsPerId,
                     final HttpsConfiguration httpsConfig) {
         this.httpsConfig = httpsConfig;
-        this.serviceConfig = serviceConfig;
+        this.serviceConfigsPerId = serviceConfigsPerId;
+
+        // now, create a map of <service type, list<config>> from <service id, config> map
+        serviceConfigsByType = new HashMap<>();
+
+        for (ServiceConfiguration serviceConfiguration : serviceConfigsPerId.values()) {
+            final String serviceType = serviceConfiguration.getType();
+            List<ServiceConfiguration> configsForType = serviceConfigsByType.get(serviceType);
+            if (configsForType == null) {
+                configsForType = new ArrayList<>();
+                serviceConfigsByType.put(serviceType, configsForType);
+            }
+            configsForType.add(serviceConfiguration);
+        }
     }
 
     public static class Builder {
@@ -41,12 +62,16 @@ public class MobileCoreConfiguration {
     }
 
     /**
-     * Get the services configuration.
+     * Get the services configuration. Map of service ids to service configurations.
      *
      * @return Services details from mobile core config.
      */
-    public Map<String, ServiceConfiguration> getServicesConfig() {
-        return Collections.unmodifiableMap(serviceConfig);
+    public Map<String, ServiceConfiguration> getServicesConfigPerId() {
+        return Collections.unmodifiableMap(serviceConfigsPerId);
+    }
+
+    public Map<String, List<ServiceConfiguration>> getServiceConfigsPerType() {
+        return Collections.unmodifiableMap(serviceConfigsByType);
     }
 
     /**

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
@@ -46,7 +46,7 @@ public final class MobileCoreJsonParser {
     private Map<String, ServiceConfiguration> parseMobileCoreArray(final JSONArray array)
                     throws JSONException, IOException {
         final int length = nonNull(array, "json array").length();
-        Map<String, ServiceConfiguration> serviceConfigs = new HashMap<>();
+        final Map<String, ServiceConfiguration> serviceConfigs = new HashMap<>(length);
         for (int i = 0; i < length; i++) {
             ServiceConfiguration serviceConfig = parseConfigObject(array.getJSONObject(i));
             serviceConfigs.put(serviceConfig.getId(), serviceConfig);
@@ -58,11 +58,9 @@ public final class MobileCoreJsonParser {
                     throws JSONException, IOException {
         nonNull(jsonObject, "jsonObject");
 
-        final ServiceConfiguration.Builder serviceConfigBuilder =
-                        ServiceConfiguration.newConfiguration();
-        serviceConfigBuilder.setId(jsonObject.getString("id"));
-        serviceConfigBuilder.setUrl(jsonObject.getString("url"));
-        serviceConfigBuilder.setType(jsonObject.getString("type"));
+        final ServiceConfiguration.Builder serviceConfigBuilder = ServiceConfiguration
+                        .newConfiguration().setId(jsonObject.getString("id"))
+                        .setUrl(jsonObject.getString("url")).setType(jsonObject.getString("type"));
 
         final JSONObject nestedConfig = jsonObject.getJSONObject("config");
         final JSONArray nestedConfigKeys = nestedConfig.names();

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/MobileCoreJsonParser.java
@@ -49,7 +49,7 @@ public final class MobileCoreJsonParser {
         Map<String, ServiceConfiguration> serviceConfigs = new HashMap<>();
         for (int i = 0; i < length; i++) {
             ServiceConfiguration serviceConfig = parseConfigObject(array.getJSONObject(i));
-            serviceConfigs.put(serviceConfig.getName(), serviceConfig);
+            serviceConfigs.put(serviceConfig.getId(), serviceConfig);
         }
         return serviceConfigs;
     }
@@ -60,17 +60,18 @@ public final class MobileCoreJsonParser {
 
         final ServiceConfiguration.Builder serviceConfigBuilder =
                         ServiceConfiguration.newConfiguration();
-        serviceConfigBuilder.setName(jsonObject.getString("name"));
+        serviceConfigBuilder.setId(jsonObject.getString("id"));
         serviceConfigBuilder.setUrl(jsonObject.getString("url"));
         serviceConfigBuilder.setType(jsonObject.getString("type"));
 
-        final JSONObject config = jsonObject.getJSONObject("config");
-        final JSONArray namesArray = config.names();
-        if (namesArray != null) {
-            int namesSize = namesArray.length();
-            for (int i = 0; i < namesSize; i++) {
-                final String name = namesArray.getString(i);
-                serviceConfigBuilder.addProperty(name, config.getString(name));
+        final JSONObject nestedConfig = jsonObject.getJSONObject("config");
+        final JSONArray nestedConfigKeys = nestedConfig.names();
+        if (nestedConfigKeys != null) {
+            int nestedConfigKeyCount = nestedConfigKeys.length();
+            for (int i = 0; i < nestedConfigKeyCount; i++) {
+                final String nestedConfigKey = nestedConfigKeys.getString(i);
+                serviceConfigBuilder.addProperty(nestedConfigKey,
+                                nestedConfig.getString(nestedConfigKey));
             }
         }
         return serviceConfigBuilder.build();

--- a/core/src/main/java/org/aerogear/mobile/core/configuration/ServiceConfiguration.java
+++ b/core/src/main/java/org/aerogear/mobile/core/configuration/ServiceConfiguration.java
@@ -9,14 +9,14 @@ import java.util.Map;
  */
 public final class ServiceConfiguration {
 
-    private final String name;
+    private final String id;
     private final String type;
     private final String url;
     private final Map<String, String> properties;
 
-    private ServiceConfiguration(final String name, final Map<String, String> properties,
+    private ServiceConfiguration(final String id, final Map<String, String> properties,
                     final String type, final String url) {
-        this.name = name;
+        this.id = id;
         this.properties = properties;
         this.type = type;
         this.url = url;
@@ -24,13 +24,13 @@ public final class ServiceConfiguration {
 
     public static class Builder {
 
-        protected String name;
+        protected String id;
         protected Map<String, String> properties = new HashMap<>();
         protected String type;
         protected String uri;
 
-        public Builder setName(final String name) {
-            this.name = name;
+        public Builder setId(final String id) {
+            this.id = id;
             return this;
         }
 
@@ -51,12 +51,12 @@ public final class ServiceConfiguration {
 
 
         public ServiceConfiguration build() {
-            return new ServiceConfiguration(this.name, this.properties, this.type, this.uri);
+            return new ServiceConfiguration(this.id, this.properties, this.type, this.uri);
         }
     }
 
-    public String getName() {
-        return name;
+    public String getId() {
+        return id;
     }
 
     public Map<String, String> getProperties() {

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpServiceModule.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpServiceModule.java
@@ -49,9 +49,6 @@ public class OkHttpServiceModule implements HttpServiceModule {
     }
 
     @Override
-    public void destroy() {}
-
-    @Override
     public HttpRequest newRequest() {
         return new OkHttpRequest(client, new AppExecutors());
     }

--- a/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
+++ b/core/src/main/java/org/aerogear/mobile/core/metrics/MetricsService.java
@@ -53,9 +53,6 @@ public class MetricsService implements ServiceModule {
         return true;
     }
 
-    @Override
-    public void destroy() {}
-
     /**
      * Send default metrics
      */

--- a/core/src/test/assets/mobile-services-multiple-services-for-type.json
+++ b/core/src/test/assets/mobile-services-multiple-services-for-type.json
@@ -31,6 +31,13 @@
             "type": "metrics",
             "url": "https://www.mocky.io/v2/5a79c6572e000028009a5c4f",
             "config": {}
+        },
+        {
+            "id": "metrics-yourapp-android",
+            "name": "metrics",
+            "type": "metrics",
+            "url": "https://www.mocky.io/v2/5a79c6572e000028009a5c4f",
+            "config": {}
         }
     ]
 }

--- a/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/MobileCoreTest.java
@@ -3,7 +3,6 @@ package org.aerogear.mobile.core.unit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,39 +56,11 @@ public class MobileCoreTest {
     }
 
     @Test
-    public void testGetCachedInstance() {
-        MobileCore.init(context);
-
-        MetricsService service1 = MobileCore.getInstance().getService(MetricsService.class);
-        MetricsService service2 = MobileCore.getInstance().getService(MetricsService.class);
-
-        assertNotNull(service1);
-        assertNotNull(service2);
-        assertEquals(service1, service2);
-    }
-
-    @Test
-    public void testAllServicesAreDestroyed() {
-        MobileCore.init(context);
-
-        DummyServiceModule service1 = MobileCore.getInstance().getService(DummyServiceModule.class);
-        DummyServiceModule service2 = MobileCore.getInstance().getService(DummyServiceModule.class);
-
-        Assert.assertFalse(service1.isDestroyed());
-        Assert.assertFalse(service2.isDestroyed());
-
-        MobileCore.getInstance().destroy();
-
-        Assert.assertTrue(service1.isDestroyed());
-        Assert.assertTrue(service2.isDestroyed());
-    }
-
-    @Test
     public void testGetServiceConfiguration() {
         MobileCore.init(context);
 
         ServiceConfiguration serviceConfiguration =
-                        MobileCore.getInstance().getServiceConfiguration("keycloak");
+                        MobileCore.getInstance().getServiceConfigurationByType("keycloak");
 
         String url = "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6";
         assertEquals(url, serviceConfiguration.getUrl());
@@ -98,8 +69,6 @@ public class MobileCoreTest {
     // -- Helpers ---------------------------------------------------------------------------------
 
     public static final class DummyServiceModule implements ServiceModule {
-
-        private boolean destroyed = false;
 
         @Override
         public String type() {
@@ -112,15 +81,6 @@ public class MobileCoreTest {
         @Override
         public boolean requiresConfiguration() {
             return false;
-        }
-
-        @Override
-        public void destroy() {
-            destroyed = true;
-        }
-
-        public boolean isDestroyed() {
-            return destroyed;
         }
     }
 

--- a/core/src/test/java/org/aerogear/mobile/core/unit/configuration/MobileCoreParserTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/configuration/MobileCoreParserTest.java
@@ -1,11 +1,13 @@
 package org.aerogear.mobile.core.unit.configuration;
 
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 import org.json.JSONException;
@@ -31,13 +33,80 @@ public class MobileCoreParserTest {
 
         try (InputStream configStream = context.getAssets().open("mobile-services.json")) {
             MobileCoreConfiguration jsonConfig = new MobileCoreJsonParser(configStream).parse();
-            Map<String, ServiceConfiguration> configs = jsonConfig.getServicesConfig();
 
-            assertNotNull(configs.get("metrics"));
+            // test things by id
+            {
+                Map<String, ServiceConfiguration> configsPerId =
+                                jsonConfig.getServicesConfigPerId();
 
-            ServiceConfiguration keyCloakServiceConfiguration = configs.get("keycloak");
-            assertEquals("https://keycloak-myproject.192.168.64.74.nip.io/auth",
-                            keyCloakServiceConfiguration.getProperty("auth-server-url"));
+                assertNotNull(configsPerId.get("metrics-myapp-android"));
+
+                ServiceConfiguration keyCloakServiceConfiguration =
+                                configsPerId.get("keycloak-myapp-android");
+                assertEquals("https://keycloak-myproject.192.168.64.74.nip.io/auth",
+                                keyCloakServiceConfiguration.getProperty("auth-server-url"));
+            }
+
+            // test things by type
+            {
+                Map<String, List<ServiceConfiguration>> configsPerType =
+                                jsonConfig.getServiceConfigsPerType();
+
+                assertTrue(configsPerType.get("metrics") != null
+                                && configsPerType.get("metrics").size() == 1);
+
+                List<ServiceConfiguration> keycloakConfigs = configsPerType.get("keycloak");
+                assertTrue(keycloakConfigs != null && keycloakConfigs.size() == 1);
+                ServiceConfiguration keycloakConfig = keycloakConfigs.get(0);
+                assertEquals("https://keycloak-myproject.192.168.64.74.nip.io/auth",
+                                keycloakConfig.getProperty("auth-server-url"));
+            }
+        } catch (JSONException | IOException exception) {
+            System.out.println(exception);
+            fail(exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testMobileCoreParsingWithMultipleConfigsForServices() throws IOException {
+        Application context = RuntimeEnvironment.application;
+
+        try (InputStream configStream = context.getAssets()
+                        .open("mobile-services-multiple-services-for-type.json")) {
+            MobileCoreConfiguration jsonConfig = new MobileCoreJsonParser(configStream).parse();
+
+            // test things by id
+            {
+                Map<String, ServiceConfiguration> configsPerId =
+                                jsonConfig.getServicesConfigPerId();
+
+                assertNotNull(configsPerId.get("metrics-myapp-android"));
+                assertNotNull(configsPerId.get("metrics-yourapp-android"));
+
+                ServiceConfiguration keyCloakServiceConfiguration =
+                                configsPerId.get("keycloak-myapp-android");
+                assertEquals("https://keycloak-myproject.192.168.64.74.nip.io/auth",
+                                keyCloakServiceConfiguration.getProperty("auth-server-url"));
+            }
+
+            // test things by type
+            {
+                Map<String, List<ServiceConfiguration>> configsPerType =
+                                jsonConfig.getServiceConfigsPerType();
+
+                List<ServiceConfiguration> metricsConfigs = configsPerType.get("metrics");
+                assertTrue(metricsConfigs != null && metricsConfigs.size() == 2);
+                assertEquals("metrics-yourapp-android", metricsConfigs.get(0).getId());
+                assertEquals("metrics-myapp-android", metricsConfigs.get(1).getId());
+
+
+                List<ServiceConfiguration> keycloakConfigs = configsPerType.get("keycloak");
+                assertTrue(keycloakConfigs != null && keycloakConfigs.size() == 1);
+                ServiceConfiguration keycloakConfig = keycloakConfigs.get(0);
+                assertEquals("https://keycloak-myproject.192.168.64.74.nip.io/auth",
+                                keycloakConfig.getProperty("auth-server-url"));
+            }
+
         } catch (JSONException | IOException exception) {
             System.out.println(exception);
             fail(exception.getMessage());

--- a/core/src/test/java/org/aerogear/mobile/core/unit/configuration/ServiceConfigurationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/configuration/ServiceConfigurationTest.java
@@ -12,11 +12,11 @@ public class ServiceConfigurationTest {
 
     @Test
     public void testCreateConfig() {
-        ServiceConfiguration config = ServiceConfiguration.newConfiguration().setName("conf-name")
+        ServiceConfiguration config = ServiceConfiguration.newConfiguration().setId("conf-id")
                         .setType("conf-type").setUrl("http://test-uri.feedhenry.org")
                         .addProperty("prop1", "value1").addProperty("prop2", "value2").build();
 
-        Assert.assertEquals("conf-name", config.getName());
+        Assert.assertEquals("conf-id", config.getId());
         Assert.assertEquals("conf-type", config.getType());
         Assert.assertEquals("http://test-uri.feedhenry.org", config.getUrl());
         Assert.assertEquals(2, config.getProperties().size());

--- a/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ExampleApplication.java
@@ -2,15 +2,7 @@ package org.aerogear.mobile.example;
 
 import android.app.Application;
 
-import org.aerogear.mobile.core.MobileCore;
 
 public class ExampleApplication extends Application {
-
-    @Override
-    public void onTerminate() {
-        super.onTerminate();
-
-        MobileCore.getInstance().destroy();
-    }
 
 }

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -103,9 +103,6 @@ public class PushService implements ServiceModule {
         return true;
     }
 
-    @Override
-    public void destroy() {}
-
     /**
      * Register the device on Unified Push Server
      *


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-2669

## Description

* After discussion on the mailing list [1] [2], we needed to adapt the SDK in terms of how to get the configs for the services.
* Before, we were using "name" properties for getting the service config. Now we need to use "id" and/or "type" properties.

What's done:
* Introduced methods on MobileCore to
  * get config by id --> needed for custom runtime connectors
  * get configs by type --> needed when there are multiple configs for a service type
  * get config by type --> similar to above, but gets the first one found. this is the one used by mobile core by default for services created automatically (Metrics, Keycloak etc). This is basically the old "getServiceConfiguration" method modified.
* Got rid of the service cache in MobileCore because of the idea that we can have multiple instances of a service for different configs
* Got rid of `destroy` methods in `ServiceModule` impls, because we don't store the initialized services in the cache anymore. Also, all of the `destroy` method impls were empty


[1]: https://groups.google.com/forum/#!topic/aerogear/1hxhEPBASVY
[2]: https://groups.google.com/forum/#!topic/aerogear/tXsNboCR-8A

## Additional Notes

~~WIP PR!
I will do the changes in the example app after we agree on the SDK changes.~~
