### PR TITLE
[WIP] Add standalone push feature

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -25,4 +25,5 @@ project.ext {
 
     // Push
     firebase_version = "15.0.0"
+    gson_version = "2.8.4"
 }

--- a/example/src/main/java/org/aerogear/mobile/example/ui/PushFragment.java
+++ b/example/src/main/java/org/aerogear/mobile/example/ui/PushFragment.java
@@ -1,9 +1,5 @@
 package org.aerogear.mobile.example.ui;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
-
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -15,12 +11,15 @@ import android.widget.Toast;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.reactive.Responder;
-import org.aerogear.mobile.example.R;
 import org.aerogear.mobile.example.handler.NotificationBarMessageHandler;
 import org.aerogear.mobile.push.MessageHandler;
 import org.aerogear.mobile.push.PushService;
 import org.aerogear.mobile.push.UnifiedPushConfig;
 import org.aerogear.mobile.push.UnifiedPushMessage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
 
 import butterknife.BindView;
 import butterknife.OnClick;
@@ -40,14 +39,16 @@ public class PushFragment extends BaseFragment implements MessageHandler {
     Button unregister;
 
     private static final String TAG = PushFragment.class.getName();
+    private PushService pushService;
     private ArrayAdapter<String> adapter;
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
+        pushService = new PushService.Builder().openshift("push").build();
         adapter = new ArrayAdapter<>(getContext(), android.R.layout.simple_list_item_1,
-                        new ArrayList<>());
+            new ArrayList<>());
         messageList.setAdapter(adapter);
     }
 
@@ -77,8 +78,7 @@ public class PushFragment extends BaseFragment implements MessageHandler {
 
     @OnClick(R.id.refreshToken)
     void refreshToken() {
-        PushService pushService = MobileCore.getInstance().getService(PushService.class);
-        pushService.refreshToken();
+        PushService.refreshToken(getContext());
     }
 
     @OnClick(R.id.register)
@@ -89,25 +89,25 @@ public class PushFragment extends BaseFragment implements MessageHandler {
         unifiedPushConfig.setAlias("AeroGear");
         unifiedPushConfig.setCategories(Arrays.asList("Android", "Example"));
 
-        PushService pushService = MobileCore.getInstance().getService(PushService.class);
         pushService.registerDevice().respondOn(new AppExecutors().mainThread())
-                        .respondWith(new Responder<Boolean>() {
+            .respondWith(new Responder<Boolean>() {
 
-                            @Override
-                            public void onResult(Boolean value) {
-                                registered(value);
-                            }
+                @Override
+                public void onResult(Boolean value) {
+                    registered(value);
+                }
 
-                            @Override
-                            public void onException(Exception error) {
-                                register.setEnabled(true);
-                                MobileCore.getLogger().error(TAG, error.getMessage(), error);
-                                registered(false);
-                                Toast.makeText(getContext(), R.string.device_register_error,
-                                                Toast.LENGTH_LONG).show();
-                            }
+                @Override
+                public void onException(Exception error) {
+                    register.setEnabled(true);
+                    MobileCore.getLogger().error(TAG, error.getMessage(), error);
+                    registered(false);
+                    Toast.makeText(getContext(), R.string.device_register_error,
+                        Toast.LENGTH_LONG).show();
+                }
 
-                        });
+            });
+
     }
 
     @OnClick(R.id.unregister)
@@ -115,26 +115,25 @@ public class PushFragment extends BaseFragment implements MessageHandler {
         refreshToken.setEnabled(false);
         unregister.setEnabled(false);
 
-        PushService pushService = MobileCore.getInstance().getService(PushService.class);
         pushService.unregisterDevice().respondOn(new AppExecutors().mainThread())
-                        .respondWith(new Responder<Boolean>() {
-                            @Override
-                            public void onResult(Boolean value) {
-                                new AppExecutors().mainThread().execute(() -> registered(false));
-                            }
+            .respondWith(new Responder<Boolean>() {
+                @Override
+                public void onResult(Boolean value) {
+                    new AppExecutors().mainThread().execute(() -> registered(false));
+                }
 
-                            @Override
-                            public void onException(Exception error) {
-                                refreshToken.setEnabled(false);
-                                register.setEnabled(false);
-                                MobileCore.getLogger().error(error.getMessage(), error);
-                                new AppExecutors().mainThread().execute(() -> {
-                                    registered(true);
-                                    Toast.makeText(getContext(), R.string.device_register_error,
-                                                    Toast.LENGTH_LONG).show();
-                                });
-                            }
-                        });
+                @Override
+                public void onException(Exception error) {
+                    refreshToken.setEnabled(false);
+                    register.setEnabled(false);
+                    MobileCore.getLogger().error(error.getMessage(), error);
+                    new AppExecutors().mainThread().execute(() -> {
+                        registered(true);
+                        Toast.makeText(getContext(), R.string.device_register_error,
+                            Toast.LENGTH_LONG).show();
+                    });
+                }
+            });
     }
 
     private void registered(boolean registered) {

--- a/push/build.gradle
+++ b/push/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(path: ":core")
 
     implementation "com.google.firebase:firebase-messaging:${project.ext.firebase_version}"
+    implementation "com.google.code.gson:gson:${project.ext.gson_version}"
 
     testImplementation "junit:junit:${project.ext.junit_version}"
     testImplementation "com.android.support.test:runner:${project.ext.android_support_test_runner_version}"

--- a/push/src/main/java/org/aerogear/mobile/push/UnifiedPushCredentials.java
+++ b/push/src/main/java/org/aerogear/mobile/push/UnifiedPushCredentials.java
@@ -2,9 +2,28 @@ package org.aerogear.mobile.push;
 
 public final class UnifiedPushCredentials {
 
+    private String url;
     private String variant;
     private String secret;
     private String senderId;
+
+    /**
+     * The URL of the Unified Push Server
+     *
+     * @return the current Unified Push Server url
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * The URL of the Unified Push Server
+     *
+     * @param url the current Unified Push Server url
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
     /**
      * ID of the variant from the AeroGear UnifiedPush Server.
@@ -44,7 +63,7 @@ public final class UnifiedPushCredentials {
 
     /**
      * Firebase senderId registered for this application.
-     * 
+     *
      * @return senderId
      */
     public String getSenderId() {

--- a/push/src/main/java/org/aerogear/mobile/push/fcm/AeroGearFirebaseInstanceIdService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/fcm/AeroGearFirebaseInstanceIdService.java
@@ -2,7 +2,6 @@ package org.aerogear.mobile.push.fcm;
 
 import com.google.firebase.iid.FirebaseInstanceIdService;
 
-import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.push.PushService;
 
 /**
@@ -20,7 +19,7 @@ public class AeroGearFirebaseInstanceIdService extends FirebaseInstanceIdService
     public void onTokenRefresh() {
         super.onTokenRefresh();
 
-        MobileCore.getInstance().getService(PushService.class).refreshToken();
+        PushService.refreshToken(getApplicationContext());
     }
 
 }


### PR DESCRIPTION
## Related issues

* [AGDROID-811](https://issues.jboss.org/browse/AGDROID-811) - Make current Android SDK able to use UPS standalone

## Target

### Openshift projects

Credentials provided by _mobile-services.json_

```
{
    "version": 1,
    "clusterName": "https://someURL",
    "namespace": "myNamespace
    "clientId": "myClienId",
    "services": [
        {
            "id": "myPushId",
            "name": "push",
            "url": "https://someURL/",
            "type": "push",
            "config": {
                "android": {
                    "variantId": "[variant id]",
                    "variantSecret": "[variant secret]",
                    "senderId": "[firebase project number]"
                }
            }
        }
    ]
}
```

```
PushService pushService = new PushService.Builder().openshift("myPushId").build();
```

### UPS standalone instance

Credentials provided by _push-config.json_

```
{
  "pushServerURL": "pushServerURL (e.g http(s)//host:port/context)",
  "android": {
    "senderId": "senderID (e.g Google Project ID only for android)",
    "variantId": "variantID (e.g. 1234456-234320)",
    "variantSecret": "variantSecret (e.g. 1234456-234320)"
  }
}
```

```java
PushService pushService = new PushService.Builder().standard().build();
```

## Credentials provided in the code

```java
UnifiedPushCredentials unifiedPushCredentials = new UnifiedPushCredentials();
unifiedPushCredentials.setUrl("http://someURL/");
unifiedPushCredentials.setSenderId("the sender id");
unifiedPushCredentials.setVariant("the variant");
unifiedPushCredentials.setSecret("the secret");

PushService pushService = new PushService(context, unifiedPushCredentials);
```

## Progress

- [x] Store push credentials
- [x] Decouple Push Service creation from MobileCore
- [ ] Support Unified Push Server standard alone instance
