### PR TITLE
fix paths to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@
 
 ## Documentation
 
-1. [End User Getting Started Guide](./docs/modules/getting-started/pages/getting-started.adoc)
-1. [Self Defence Checks](./docs/modules/getting-started/pages/auth-self-defence-checks.adoc)
-1. [Certificate Pinning](./docs/modules/getting-started/pages/certificate-pinning.adoc)
+1. [End User Getting Started Guide](./docs/modules/ROOT/pages/index.adoc)
+1. [Self Defence Checks](./docs/modules/ROOT/pages/auth-self-defence-checks.adoc)
+1. [Certificate Pinning](./docs/modules/ROOT/pages/certificate-pinning.adoc)
 1. [Troubleshooting](./docs/troubleshooting.adoc)
-1. [Service Contributor Guide](./docs/contributing-guide.adoc)
+1. [Service Contributor Guide](./docs/contrib/contributing-guide.adoc)
 
 ### List of SDKs
 
 AeroGear Services SDK consist of set of separate SDKs
 
-- [Auth](./docs/modules/getting-started/pages/auth.adoc):  Mobile authentication SDK
-- [Push](./docs/modules/getting-started/pages/push.adoc):  Push Notifications SDK
+- [Auth](./docs/modules/ROOT/pages/auth.adoc):  Mobile authentication SDK
+- [Push](./docs/modules/ROOT/pages/push.adoc):  Push Notifications SDK
 
 ## License 
 

--- a/docs/modules/ROOT/pages/push.adoc
+++ b/docs/modules/ROOT/pages/push.adoc
@@ -51,17 +51,14 @@ This example demonstrates how to register a device to provide the values require
 ----
 PushService pushService = MobileCore.getInstance().getService(PushService.class);
 
-pushService.registerDevice(new Callback() {
+push.registerDevice().requestOn(new AppExecutors().mainThread()).respondWith(new Responder<Boolean>() {
     @Override
-    public void onSuccess() {
-        // Yay
-    }
+    public void onResult(Boolean value) { // Yay }
 
     @Override
-    public void onError(Throwable error) {
-        // Oops!
-    }
+    public void onException(Exception exception) { // Oops! }
 });
+
 ----
 
 You also can add some optional parameters using `UnifiedPushConfig`


### PR DESCRIPTION
Fix the paths to the docs in the README (looks like they changed with Antora). Also updates the example code to register a device for push.
