### PR TITLE
Fixed node label in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,8 @@ if ( prLabels.contains("test/integration") ) {
     }
 
     openshift.withCluster() {
-        node ('jenkins-openshift') {
+        // Node with privilege to create projects on Wendy
+        node ('apb-test') {
             stage ('Deploy app metrics service') {
 
                 sh "curl ${linkToApiMetricsTemplate} > ${apiMetricsTemplateFilename}"


### PR DESCRIPTION
## Motivation
Integration test in Jenkins was hanging because of incorrect name of the node label
