### PR TITLE
Decouple Push Service creation from MobileCore

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -25,4 +25,5 @@ project.ext {
 
     // Push
     firebase_version = "15.0.0"
+    gson_version = "2.8.4"
 }

--- a/docs/modules/ROOT/pages/using-push-sdk.adoc
+++ b/docs/modules/ROOT/pages/using-push-sdk.adoc
@@ -51,7 +51,7 @@ This example demonstrates how to register a device to provide the values require
 
 [source,java]
 ----
-PushService pushService = MobileCore.getInstance().getService(PushService.class);
+PushService pushService = new PushService.Builder().openshift().build();
 ----
 
 === Registering the device

--- a/push/build.gradle
+++ b/push/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(path: ":core")
 
     implementation "com.google.firebase:firebase-messaging:${project.ext.firebase_version}"
+    implementation "com.google.code.gson:gson:${project.ext.gson_version}"
 
     testImplementation "junit:junit:${project.ext.junit_version}"
     testImplementation "com.android.support.test:runner:${project.ext.android_support_test_runner_version}"

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -91,13 +91,14 @@ public class PushService {
 
         public Builder() {}
 
-        public Builder openshift(String id) {
+        public Builder openshift() {
 
             MobileCore mobileCore = MobileCore.getInstance();
 
             context = mobileCore.getContext();
 
-            ServiceConfiguration serviceConfiguration = mobileCore.getServiceConfigurationById(id);
+            ServiceConfiguration serviceConfiguration =
+                            mobileCore.getServiceConfigurationByType("push");
 
             try {
                 JSONObject android = new JSONObject(

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -40,6 +40,8 @@ import org.aerogear.mobile.core.reactive.Responder;
  */
 public class PushService {
 
+    public static final String TYPE = "push";
+
     private static final String TAG = PushService.class.getName();
 
     private static final String DEFAULT_MESSAGE_HANDLER_KEY = "DEFAULT_MESSAGE_HANDLER_KEY";
@@ -98,7 +100,7 @@ public class PushService {
             context = mobileCore.getContext();
 
             ServiceConfiguration serviceConfiguration =
-                            mobileCore.getServiceConfigurationByType("push");
+                            mobileCore.getServiceConfigurationByType(TYPE);
 
             try {
                 JSONObject android = new JSONObject(

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -275,6 +275,8 @@ public class PushService {
 
     /**
      * Update the device token on Unified Push Server
+     *
+     * @param context Application context
      */
     public static void refreshToken(Context context) {
         nonNull(context, "context");

--- a/push/src/main/java/org/aerogear/mobile/push/PushService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/PushService.java
@@ -79,8 +79,8 @@ public class PushService {
 
         this.unifiedPushCredentials = unifiedPushCredentials;
 
-        setDefaultHandler(context);
-        setSharedPreference(context);
+        initDefaultHandler(context);
+        initSharedPreference(context);
 
     }
 
@@ -279,7 +279,7 @@ public class PushService {
         nonNull(context, "context");
 
         if (sharedPreferences == null) {
-            setSharedPreference(context);
+            initSharedPreference(context);
         }
 
         JSONObject jsonObject = retrieveCachedConfig();
@@ -418,7 +418,7 @@ public class PushService {
         nonNull(context, "context");
 
         if (defaultHandler == null) {
-            setDefaultHandler(context);
+            initDefaultHandler(context);
         }
 
         if (BACKGROUND_THREAD_HANDLERS.isEmpty() && MAIN_THREAD_HANDLERS.isEmpty()
@@ -450,7 +450,7 @@ public class PushService {
      * </code>
      */
     @SuppressWarnings("unchecked")
-    private static void setDefaultHandler(final Context context) {
+    private static void initDefaultHandler(final Context context) {
         nonNull(context, "context");
 
         try {
@@ -487,7 +487,7 @@ public class PushService {
      *
      * @param context Application context
      */
-    private static void setSharedPreference(Context context) {
+    private static void initSharedPreference(Context context) {
         sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCE_PUSH_NAME,
                         Context.MODE_PRIVATE);
     }

--- a/push/src/main/java/org/aerogear/mobile/push/UnifiedPushCredentials.java
+++ b/push/src/main/java/org/aerogear/mobile/push/UnifiedPushCredentials.java
@@ -23,6 +23,10 @@ public final class UnifiedPushCredentials {
      */
     public void setUrl(String url) {
         this.url = url;
+
+        if (!this.url.endsWith("/")) {
+            this.url = this.url.concat("/");
+        }
     }
 
     /**

--- a/push/src/main/java/org/aerogear/mobile/push/UnifiedPushCredentials.java
+++ b/push/src/main/java/org/aerogear/mobile/push/UnifiedPushCredentials.java
@@ -2,9 +2,28 @@ package org.aerogear.mobile.push;
 
 public final class UnifiedPushCredentials {
 
+    private String url;
     private String variant;
     private String secret;
     private String senderId;
+
+    /**
+     * The URL of the Unified Push Server
+     *
+     * @return the current Unified Push Server url
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * The URL of the Unified Push Server
+     *
+     * @param url the current Unified Push Server url
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
     /**
      * ID of the variant from the AeroGear UnifiedPush Server.
@@ -44,7 +63,7 @@ public final class UnifiedPushCredentials {
 
     /**
      * Firebase senderId registered for this application.
-     * 
+     *
      * @return senderId
      */
     public String getSenderId() {

--- a/push/src/main/java/org/aerogear/mobile/push/fcm/AeroGearFirebaseInstanceIdService.java
+++ b/push/src/main/java/org/aerogear/mobile/push/fcm/AeroGearFirebaseInstanceIdService.java
@@ -2,7 +2,6 @@ package org.aerogear.mobile.push.fcm;
 
 import com.google.firebase.iid.FirebaseInstanceIdService;
 
-import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.push.PushService;
 
 /**
@@ -20,7 +19,7 @@ public class AeroGearFirebaseInstanceIdService extends FirebaseInstanceIdService
     public void onTokenRefresh() {
         super.onTokenRefresh();
 
-        MobileCore.getInstance().getService(PushService.class).refreshToken();
+        PushService.refreshToken(getApplicationContext());
     }
 
 }


### PR DESCRIPTION

## Related issues

This is part of the [AGDROID-796](https://issues.jboss.org/browse/AGDROID-796)

## Target

### Openshift projects

Credentials provided by _mobile-services.json_

```
{
    "version": 1,
    "clusterName": "https://someURL",
    "namespace": "myNamespace
    "clientId": "myClienId",
    "services": [
        {
            "id": "myPushId",
            "name": "push",
            "url": "https://someURL/",
            "type": "push",
            "config": {
                "android": {
                    "variantId": "[variant id]",
                    "variantSecret": "[variant secret]",
                    "senderId": "[firebase project number]"
                }
            }
        }
    ]
}
```

Replace:

```java
PushService pushService = MobileCore.getInstance().getService(PushService.class);
```

By

```java
PushService pushService = new PushService.Builder().openshift().build();
```
