### PR TITLE
Security metrics are now sent

### DIFF
--- a/security/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
+++ b/security/src/main/java/org/aerogear/mobile/security/SecurityCheckMetricPublisher.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.metrics.MetricsService;
+import org.aerogear.mobile.core.reactive.Responder;
 import org.aerogear.mobile.security.metrics.SecurityCheckResultMetric;
 
 /**
@@ -35,6 +37,17 @@ class SecurityCheckMetricPublisher implements SecurityCheckExecutorListener {
     @Override
     public void onComplete() {
         metricsService.publish(SecurityService.SECURITY_METRICS_EVENT_TYPE,
-                        new SecurityCheckResultMetric(metricResults));
+                        new SecurityCheckResultMetric(metricResults))
+                        .respondWith(new Responder<Boolean>() {
+                            @Override
+                            public void onResult(Boolean value) {
+                                MobileCore.getLogger().debug("Metrics sent");
+                            }
+
+                            @Override
+                            public void onException(Exception exception) {
+                                MobileCore.getLogger().error("Metrics did not send", exception);
+                            }
+                        });
     }
 }

--- a/security/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
+++ b/security/src/test/java/org/aerogear/mobile/security/SecurityCheckExecutorTest.java
@@ -26,6 +26,7 @@ import android.content.Context;
 
 import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.metrics.MetricsService;
+import org.aerogear.mobile.core.reactive.Requester;
 import org.aerogear.mobile.security.impl.SecurityCheckResultImpl;
 
 @RunWith(RobolectricTestRunner.class)
@@ -47,7 +48,7 @@ public class SecurityCheckExecutorTest {
         MockitoAnnotations.initMocks(this);
 
         SecurityCheckResultImpl result = new SecurityCheckResultImpl(mockSecurityCheck, true);
-
+        when(metricsService.publish(any(), any())).thenReturn(Requester.emit(true));
         when(context.getApplicationContext()).thenReturn(context);
         when(mockSecurityCheck.test(context)).thenReturn(result);
         when(securityCheckType.getSecurityCheck()).thenReturn(mockSecurityCheck);


### PR DESCRIPTION
## Motivation

The showcase app wasn't sending metrics for device checks.  This is now fixed

JIRA: https://issues.jboss.org/browse/AEROGEAR-3130

## Description

The metrics published was not attaching a responder to a request object.  Rx objects don't run unless they have a response to send things to.  There may be a need to update some javadocs to clarify this at the metricsPublisher level; this is documented behavior on the Request class as well as a standard Rx pattern (cold single observable) which is documented on the request class as well.

## Progress

- [x] Metrics send

## Additional Notes

To verify this issue you can use the showcase app, you will need to provision metrics and make sure that you either import the https certificate or use an insecure route.

![image](https://user-images.githubusercontent.com/2413816/41356671-5e98412c-6ef2-11e8-8b6f-cf8caa966b29.png)


