### PR TITLE
Exposing http client

### DIFF
--- a/auth/src/test/java/org/aerogear/mobile/auth/AuthServiceTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/AuthServiceTest.java
@@ -14,9 +14,8 @@ import android.content.Context;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
-import org.aerogear.mobile.core.http.HttpRequest;
-import org.aerogear.mobile.core.http.HttpResponse;
-import org.aerogear.mobile.core.http.HttpServiceModule;
+import org.aerogear.mobile.core.http.OkHttpRequest;
+import org.aerogear.mobile.core.http.OkHttpServiceModule;
 
 public class AuthServiceTest {
     @Mock
@@ -33,13 +32,10 @@ public class AuthServiceTest {
 
 
     @Mock
-    HttpServiceModule httpServiceModule;
+    OkHttpServiceModule httpServiceModule;
 
     @Mock
-    HttpRequest httpRequest;
-
-    @Mock
-    HttpResponse httpResponse;
+    OkHttpRequest httpRequest;
 
     @Before
     public void setup() throws NoSuchFieldException, IllegalAccessException {

--- a/auth/src/test/java/org/aerogear/mobile/auth/credentials/JwksManagerTest.java
+++ b/auth/src/test/java/org/aerogear/mobile/auth/credentials/JwksManagerTest.java
@@ -28,9 +28,10 @@ import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
 import org.aerogear.mobile.auth.configuration.KeycloakConfiguration;
 import org.aerogear.mobile.core.Callback;
 import org.aerogear.mobile.core.MobileCore;
-import org.aerogear.mobile.core.http.HttpRequest;
 import org.aerogear.mobile.core.http.HttpResponse;
-import org.aerogear.mobile.core.http.HttpServiceModule;
+import org.aerogear.mobile.core.http.OkHttpRequest;
+import org.aerogear.mobile.core.http.OkHttpResponse;
+import org.aerogear.mobile.core.http.OkHttpServiceModule;
 import org.aerogear.mobile.core.reactive.Request;
 import org.aerogear.mobile.core.reactive.Responder;
 
@@ -52,16 +53,16 @@ public class JwksManagerTest {
     private KeycloakConfiguration keycloakConfiguration;
 
     @Mock
-    private HttpServiceModule httpServiceModule;
+    private OkHttpServiceModule httpServiceModule;
 
     @Mock
-    private HttpRequest httpRequest;
+    private OkHttpRequest httpRequest;
 
     @Mock
     private Request<HttpResponse> rxHttpRequest;
 
     @Mock
-    private HttpResponse httpResponse;
+    private OkHttpResponse httpResponse;
 
     @Mock
     private SharedPreferences sharedPrefs;

--- a/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
+++ b/core/src/main/java/org/aerogear/mobile/core/MobileCore.java
@@ -21,7 +21,6 @@ import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 import org.aerogear.mobile.core.configuration.https.HttpsConfiguration;
 import org.aerogear.mobile.core.exception.ConfigurationNotFoundException;
 import org.aerogear.mobile.core.exception.InitializationException;
-import org.aerogear.mobile.core.http.HttpServiceModule;
 import org.aerogear.mobile.core.http.OkHttpCertificatePinningParser;
 import org.aerogear.mobile.core.http.OkHttpServiceModule;
 import org.aerogear.mobile.core.logging.Logger;
@@ -49,7 +48,7 @@ public final class MobileCore {
     private final Context context;
     private final String appVersion;
     private final String configFileName = "mobile-services.json";
-    private final HttpServiceModule httpLayer;
+    private final OkHttpServiceModule httpLayer;
     private final Map<String, ServiceConfiguration> serviceConfigById;
     private final Map<String, List<ServiceConfiguration>> serviceConfigsByType;
     private final MetricsService metricsService;
@@ -235,7 +234,7 @@ public final class MobileCore {
      *
      * @return HTTP service module
      */
-    public HttpServiceModule getHttpLayer() {
+    public OkHttpServiceModule getHttpLayer() {
         return httpLayer;
     }
 

--- a/core/src/main/java/org/aerogear/mobile/core/http/HttpRequest.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/HttpRequest.java
@@ -5,7 +5,6 @@ import org.aerogear.mobile.core.reactive.Request;
 /**
  * Generic interface for requests to HTTP Services.
  */
-
 public interface HttpRequest {
 
     String CONTENT_TYPE_HEADER = "Content-Type";

--- a/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/HttpResponse.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
  * Generic interface for responses from HTTP Services. Concrete classes will have the handle
  * Android's threading mechanisms.
  */
-
 public interface HttpResponse {
     /**
      * Returns the HTTP status code of the response.

--- a/core/src/main/java/org/aerogear/mobile/core/http/OkHttpServiceModule.java
+++ b/core/src/main/java/org/aerogear/mobile/core/http/OkHttpServiceModule.java
@@ -49,7 +49,18 @@ public class OkHttpServiceModule implements HttpServiceModule {
     }
 
     @Override
-    public HttpRequest newRequest() {
+    public OkHttpRequest newRequest() {
         return new OkHttpRequest(client, new AppExecutors());
+    }
+
+    /**
+     * The client is a shared instance with all references from {@link MobileCore#getHttpLayer()}.
+     * This client is configured with the AeroGear defaults, pinning, etc. during the MobileCore
+     * initialization.
+     *
+     * @return the mobilecore okhttp instance.
+     */
+    public OkHttpClient getClient() {
+        return client;
     }
 }


### PR DESCRIPTION
## Motivation

Small refactor to expose OKHttp as our defactor http implementation.  I left the interfaces in for testing and backwards compatibility, but we can discuss removing them.

https://issues.jboss.org/browse/AEROGEAR-7542

## Description

This makes a few small changes.

MobileCore getHttpLayer returns a OkHttpService.  
OKHttpService now has a method to get the http client as well as javadocs covering how it is configured.


## Progress

- [x] Done Task

## Additional Notes

Contact @danielpassos for additional testing information.
