### PR TITLE
Sync rx

### DIFF
--- a/sync/src/main/java/org/aerogear/mobile/sync/SyncService.java
+++ b/sync/src/main/java/org/aerogear/mobile/sync/SyncService.java
@@ -1,5 +1,6 @@
 package org.aerogear.mobile.sync;
 
+import static org.aerogear.mobile.core.utils.SanityCheck.*;
 import static org.aerogear.mobile.core.utils.SanityCheck.nonNull;
 
 import javax.annotation.Nonnull;
@@ -53,16 +54,16 @@ public final class SyncService {
         return apolloClient;
     }
 
-    public SyncQuery query(Query query) {
-        return new SyncQuery(this.apolloClient, query);
+    public SyncQuery query(@Nonnull Query query) {
+        return new SyncQuery(this.apolloClient, nonNull(query, "query"));
     }
 
-    public SyncMutation mutation(Mutation mutation) {
-        return new SyncMutation(this.apolloClient, mutation);
+    public SyncMutation mutation(@Nonnull Mutation mutation) {
+        return new SyncMutation(this.apolloClient, nonNull(mutation, "mutation"));
     }
 
-    public SyncSubscription subscribe(Subscription subscription) {
-        return new SyncSubscription(this.apolloClient, subscription);
+    public SyncSubscription subscribe(@Nonnull Subscription subscription) {
+        return new SyncSubscription(this.apolloClient, nonNull(subscription, "subscription"));
     }
 
     public static class SyncQuery {
@@ -75,7 +76,10 @@ public final class SyncService {
             this.query = query;
         }
 
-        public <T extends Operation.Data> Request<Response<T>> execute(Class<T> responseDataClass) {
+        public <T extends Operation.Data> Request<Response<T>> execute(
+                        @Nonnull Class<T> responseDataClass) {
+
+            nonNull(responseDataClass, "responseDataClass");
 
             return Requester.call((Responder<Response<T>> requestCallback) -> apolloClient
                             .query(query).enqueue(new ApolloCall.Callback<T>() {
@@ -104,7 +108,10 @@ public final class SyncService {
             this.mutation = mutation;
         }
 
-        public <T extends Operation.Data> Request<Response<T>> execute(Class<T> responseDataClass) {
+        public <T extends Operation.Data> Request<Response<T>> execute(
+                        @Nonnull Class<T> responseDataClass) {
+
+            nonNull(responseDataClass, "responseDataClass");
 
             return Requester.call((Responder<Response<T>> requestCallback) -> apolloClient
                             .mutate(mutation).enqueue(new ApolloCall.Callback<T>() {
@@ -132,7 +139,10 @@ public final class SyncService {
             this.subscription = subscription;
         }
 
-        public <T extends Operation.Data> Request<Response<T>> execute(Class<T> responseDataClass) {
+        public <T extends Operation.Data> Request<Response<T>> execute(
+                        @Nonnull Class<T> responseDataClass) {
+
+            nonNull(responseDataClass, "responseDataClass");
 
             return Requester.call((Responder<Response<T>> requestCallback) -> apolloClient
                             .subscribe(subscription).execute(new ApolloSubscriptionCall.Callback() {


### PR DESCRIPTION
Related issues: 

* [AEROGEAR-7653](https://issues.jboss.org/browse/AEROGEAR-7653)

This PR create utility methods to use GraphQL query, mutation, and subscription wrapping up the Apollo client call using AeroGear Rx

Instead of doing:

```java
SyncService
        .getInstance()
        .getApolloClient()
        .query(MyQueryClassGeneratedByApollo.builder().build())
        .enqueue(new ApolloCall.Callback<MyQueryClassGeneratedByApollo.Data>() {
            @Override
            public void onResponse(@Nonnull Response<MyQueryClassGeneratedByApollo.Data> response) {
                // Yay!
            }

            @Override
            public void onFailure(@Nonnull ApolloException e) {
                // Oops!
            }
        });
```

You can do: 

```java
SyncService
        .getInstance()
        .query(MyQueryClassGeneratedByApollo.builder().build())
        .execute(MyQueryClassGeneratedByApollo.Data.class)
        .respondOn(new AppExecutors().mainThread())
        .requestMap(response -> {
            // Do some transform from Apollo model to your model
        })
        .respondWith(new Responder<List<MyModel>>() {
            @Override
            public void onResult(List<MyModel> myModelList) {
                // Do something with the list of your model
            }

            @Override
            public void onException(Exception exception) {
                // Oops!
            }
        });

```

