### PR TITLE
Updated Gradle for lint to 4.6

### DIFF
--- a/codequality/lint/gradle/wrapper/gradle-wrapper.properties
+++ b/codequality/lint/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
## Motivation

`./gradlew checks:jar` command does not work with 4.1. And besides Gradle 4.6 is used everywhere else.