### PR TITLE
Fixing URL for app metrics integration test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,15 +68,10 @@ For running the unit tests, simly run
 
 ### Integration tests
 
-Integration tests are designed to be triggered when PR is created, but with easy configuration it's also possible to run them on your local machine (described below).
-
-To trigger the integration tests together with creation of PR, select the `test/integration` label in the right column.
-
 **Metrics integration test**
 
 This includes testing of communication between Android SDK Metrics module and [AeroGear App Metrics service](https://github.com/aerogear/aerogear-app-metrics) (part of [Metrics-APB](https://github.com/aerogearcatalog/metrics-apb))
 
-To run it locally:
+In order to run the test successfully you have to have an AeroGear App Metrics service running. Follow [the guide](https://github.com/aerogear/aerogear-app-metrics#run-entire-application-with-docker-compose) to run the Metrics service locally. You can trigger the test execution by running `./gradlew :core:testDebug --tests *.IntegrationTestSuite` afterwards.
 
-1. Edit [Metrics URL](https://github.com/aerogear/aerogear-android-sdk/blob/master/core/src/test/assets/integration-test-mobile-services.json#L11) with valid URL pointing to `/metrics` endpoint, e.g. https://app-metrics.example.com/metrics
-2. Run the test: `./gradlew :core:testDebug --tests *.IntegrationTestSuite`
+If you have Metrics service running already, just edit the [Metrics URL](https://github.com/aerogear/aerogear-android-sdk/blob/master/core/src/test/assets/mobile-services.json#L32) with a valid URL pointing to `/metrics` endpoint, e.g. https://app-metrics.example.com/metrics

--- a/core/src/test/assets/mobile-services-multiple-services-for-type.json
+++ b/core/src/test/assets/mobile-services-multiple-services-for-type.json
@@ -29,14 +29,14 @@
             "id": "metrics-myapp-android",
             "name": "metrics",
             "type": "metrics",
-            "url": "https://demo1623828.mockable.io/metrics",
+            "url": "http://localhost:3000/metrics",
             "config": {}
         },
         {
             "id": "metrics-yourapp-android",
             "name": "metrics",
             "type": "metrics",
-            "url": "https://demo1623828.mockable.io/metrics",
+            "url": "http://localhost:3000/metrics",
             "config": {}
         }
     ]

--- a/core/src/test/assets/mobile-services-type-casing.json
+++ b/core/src/test/assets/mobile-services-type-casing.json
@@ -29,7 +29,7 @@
             "id": "metrics-myapp-android",
             "name": "metrics",
             "type": "metrics",
-            "url": "https://demo1623828.mockable.io/metrics",
+            "url": "http://localhost:3000/metrics",
             "config": {}
         }
     ]

--- a/core/src/test/assets/mobile-services.json
+++ b/core/src/test/assets/mobile-services.json
@@ -29,7 +29,7 @@
             "id": "metrics-myapp-android",
             "name": "metrics",
             "type": "metrics",
-            "url": "https://demo1623828.mockable.io/metrics",
+            "url": "http://localhost:3000/metrics",
             "config": {}
         }
     ]

--- a/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/integration/MetricsServiceIntegrationTest.java
@@ -30,7 +30,7 @@ public class MetricsServiceIntegrationTest {
     @Before
     public void setUp() {
         MobileCore.init(RuntimeEnvironment.application);
-        metricsService = new MetricsService("https://demo1623828.mockable.io/metrics");
+        metricsService = MobileCore.getInstance().getMetricsService();
 
         error = null;
     }

--- a/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
+++ b/core/src/test/java/org/aerogear/mobile/core/unit/metrics/MetricsServiceTest.java
@@ -29,7 +29,7 @@ public class MetricsServiceTest {
     @Before
     public void setUp() {
         MobileCore.init(RuntimeEnvironment.application);
-        metricsService = new MetricsService("https://demo1623828.mockable.io/metrics");
+        metricsService = new MetricsService("http://dummy.io/metrics");
     }
 
     @Test


### PR DESCRIPTION
## Motivation

Metrics Integration test keeps failing and the metrics endpoint is not configurable as described.

Issue: https://github.com/aerogear/aerogear-android-sdk/issues/265

## Description

Hard-coded metrics URL in the integration test has been removed. It has been made configurable via mobile-services.json file. Already existing classes for parsing and getting the configuration have been used for that.

Some other small fixes are included that are related to this - not using the mockable.io URL at all. If the URL does not matter, that fact has been made clear by changing the URL to contain word 'dummy'.

We have to remove this note that is automatically prefilled in description of PR because it is not that easy to run the integration test now:

```
NOTE 
To run the integration tests, select "test/integration" label in the right column. Check the Jenkins log to get the test results
```

And also this test should be running nightly somewhere or we should make it work per PR again (I will try to make it happen).


