### PR TITLE
Execute unit tests before publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: TAG=$CIRCLE_TAG ./scripts/validateRelease.sh
       - run:
           name: Release to Nexus
-          command: ./gradlew clean build -x test uploadArchives -PNEXUS_USERNAME=$NEXUS_USERNAME -PNEXUS_PASSWORD=$NEXUS_PASSWORD
+          command: ./gradlew clean build uploadArchives -PNEXUS_USERNAME=$NEXUS_USERNAME -PNEXUS_PASSWORD=$NEXUS_PASSWORD
 
 workflows:
   version: 2


### PR DESCRIPTION
## Motivation

Having https://github.com/aerogear/aerogear-android-sdk/pull/270 merged it is OK to run `test` task since this task only triggers unit test execution. And we definitely don't want to upload archives if the unit tests are failing.

This is basically a revert of https://github.com/aerogear/aerogear-android-sdk/commit/c67c0503a5d75ba754ef1475f84c42c69e2ad49b which is not needed any longer I think