### PR TITLE
Added Code Coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,15 @@ This includes testing of communication between Android SDK Metrics module and [A
 In order to run the test successfully you have to have an AeroGear App Metrics service running. Follow [the guide](https://github.com/aerogear/aerogear-app-metrics#run-entire-application-with-docker-compose) to run the Metrics service locally. You can trigger the test execution by running `./gradlew :core:clean :core:testDebug -PintegrationTests=true` afterwards.
 
 If you have Metrics service running already, just update the [Metrics URL](https://github.com/aerogear/aerogear-android-sdk/blob/master/core/src/test/assets/mobile-services.json#L32) with a valid URL pointing to `/metrics` endpoint, e.g. https://app-metrics.example.com/metrics
+
+### Code Coverage
+
+You can create a code coverage report for each module individually. The example below generates the code coverage report for the 'auth' module:
+`./gradlew :auth:jacocoTestReport`
+To see the report open the following file in a browser:
+`<module>/build/reports/jacoco/jacocoTestReport/html/index.html`
+
+You can also create a code coverage report for all the modules combined:
+`./gradlew jacocoRootReport`
+HTML report location:
+`build/reports/jacoco/jacocoRootReport/html/index.html`

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${project.ext.robolectric_version}"
 }
 
+apply from: "../jacoco.gradle"
 apply from: "../gradle-mvn-push.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,19 @@
 buildscript {
+
+    ext.jacocoVersion = '0.8.1'
+
+    // JaCoCo
+    ext.execFile = 'jacoco/jacocoTest.exec'
+    ext.classFilesPath = 'intermediates/javac'
+    ext.fileFilter = [
+        '**/R.class',
+        '**/R$*.class',
+        '**/BuildConfig.*',
+        '**/Manifest*.*',
+        '**/*Test*.*',
+        'android/**/*.*'
+    ]
+
     repositories {
         google()
         jcenter()
@@ -7,6 +22,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.0-alpha13'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.google.gms:google-services:3.2.1'
+        classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
     }
 }
 
@@ -45,6 +61,36 @@ subprojects {
                 type.buildConfigField 'String', 'PROJECT_ROOT', "\"" + project.projectDir.absolutePath.replace("\\", "\\\\") + "/\""
             }
     }
+}
+
+task jacocoRootReport(type: JacocoReport, group: 'Coverage reports') {
+
+  apply plugin: 'jacoco'
+
+  description = 'Generates an aggregate report from all modules - auth, core, push, and security'
+
+  subprojects.each { dependsOn("${it.name}:jacocoTestReport") }
+
+  jacocoClasspath = configurations.jacocoAnt
+
+  reports {
+    xml.enabled = true
+    html.enabled = true
+  }
+
+  def srcDirs = []
+  subprojects.each {srcDirs << "it.projectDir/src/main/java"}
+  sourceDirectories = files(srcDirs)
+
+  def classDirTrees = []
+  subprojects.each {classDirTrees << fileTree(dir: "$it.buildDir/$classFilesPath/debug", excludes: fileFilter)}
+  subprojects.each {classDirTrees << fileTree(dir: "$it.buildDir/$classFilesPath/debugUnitTest", excludes: fileFilter)}
+  subprojects.each {classDirTrees << fileTree(dir: "$it.buildDir/$classFilesPath/debugAndroidTest", excludes: fileFilter)}
+  classDirectories = files(classDirTrees)
+
+  def execData = []
+  subprojects.each {execData << "$it.buildDir/$execFile"}
+  executionData = files(execData)
 }
 
 // We want to expose the SDK version and name to the metrics subproject

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,5 +61,6 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:${project.ext.okhttp_version}"
 }
 
+apply from: "../jacoco.gradle"
 apply from: "../gradle-mvn-push.gradle"
 

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,36 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "$jacocoVersion"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+    jacoco.destinationFile = file("$buildDir/$execFile")
+}
+
+android {
+    buildTypes {
+        debug {
+            testCoverageEnabled = true
+        }
+    }
+}
+
+task jacocoTestReport(type: JacocoReport, group: 'Coverage reports') {
+
+  description = 'Generates a JaCoCo report for a single module (core/auth/push/security)'
+  dependsOn = ['testDebugUnitTest', 'createDebugCoverageReport']
+
+  reports {
+    xml.enabled = true
+    html.enabled = true
+  }
+  def debugTree = fileTree(dir: "$buildDir/$classFilesPath/debug", excludes: fileFilter);
+  def debugUnitTree = fileTree(dir: "$buildDir/$classFilesPath/debugUnitTest", excludes: fileFilter);
+  def debugAndroidTree = fileTree(dir: "$buildDir/$classFilesPath/debugAndroidTest", excludes: fileFilter);
+
+  sourceDirectories = files(['src/main/java'])
+  classDirectories = files([debugTree, debugUnitTree, debugAndroidTree])
+  executionData = files(["$buildDir/$execFile"])
+}

--- a/push/build.gradle
+++ b/push/build.gradle
@@ -34,5 +34,7 @@ dependencies {
     testImplementation "com.android.support.test:runner:${project.ext.android_support_test_runner_version}"
     testImplementation "com.android.support.test:rules:${project.ext.android_support_test_rules_version}"
 }
+
+apply from: "../jacoco.gradle"
 apply from: "../gradle-mvn-push.gradle"
 

--- a/security/build.gradle
+++ b/security/build.gradle
@@ -41,4 +41,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${project.ext.robolectric_version}"
 }
 
+apply from: "../jacoco.gradle"
 apply from: "../gradle-mvn-push.gradle"


### PR DESCRIPTION
## Motivation

Having code coverage computed is very useful.

## Description

Added some JaCoCo config and tasks that are able to generate the code coverage reports - for each module individually (jacoco.gradle) and for 'root' report that combines all the module reports together (build.gradle). The build. gradle also contains few variables used in both individual and root jacoco tasks to avoid duplicity definitions of these variables.

## Additional Notes

Next step would be to integrate with coverals or codecov and add nice badge to README.md so that we can track the trend of code coverage over the time.