### PR TITLE
Fixed command for integration tests execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ if ( prLabels.contains("test/integration") ) {
                 }
 
                 stage ('Run integration test') {
-                    sh "./gradlew :core:testDebug --tests *.IntegrationTestSuite"
+                    sh "./gradlew :core:testDebug -PintegrationTests=true"
                 }
             }
 


### PR DESCRIPTION
## Motivation

Fix of the command that triggers integration test execution. It has changed, see https://github.com/aerogear/aerogear-android-sdk/pull/270

## Progress

- [x] Done Task
- [ ] Todo Task

## Additional Notes

<!-- Optional, extra context or instructions around the contents of this Pull Request -->

<!-- NOTE -->
<!-- To run the integration tests, select "test/integration" label in the right column. Check the Jenkins log to get the test results -->
