### PR TITLE
Remove hardcoded scheme from example

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion project.ext.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = ["appAuthRedirectScheme": "org.aerogear.mobile.example"]
     }
 
     buildTypes {


### PR DESCRIPTION
Hardcoded scheme in gradle file is no longer applied and it should be removed. 
Users should specify their own version.

I'm not 100% sure about that change, but IMHO users will need to specify that in their application rather than in SDK. SDK requires schema to be passed in so this looks like value that will be never used, however in recent version of SDK I'm getting back compilation issues.