### PR TITLE
Fixed JaCoCo report after sync module addition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,16 @@ task jacocoRootReport(type: JacocoReport, group: 'Coverage reports') {
     html.enabled = true
   }
 
+  // these 'onlyIf' and 'doFirst' blocks are required since the sync module does not contain any unit tests
+  onlyIf = {
+      true
+  }
+  doFirst {
+      executionData = files(executionData.findAll {
+          it.exists()
+      })
+  }
+
   def srcDirs = []
   subprojects.each {srcDirs << "it.projectDir/src/main/java"}
   sourceDirectories = files(srcDirs)

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -20,7 +20,7 @@ android {
 task jacocoTestReport(type: JacocoReport, group: 'Coverage reports') {
 
   description = 'Generates a JaCoCo report for a single module (core/auth/push/security)'
-  dependsOn = ['testDebugUnitTest', 'createDebugCoverageReport']
+  dependsOn = ['testDebugUnitTest']
 
   reports {
     xml.enabled = true

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -35,5 +35,6 @@ dependencies {
     testImplementation "com.android.support.test:rules:${project.ext.android_support_test_rules_version}"
 }
 
+apply from: "../jacoco.gradle"
 apply from: "../gradle-mvn-push.gradle"
 


### PR DESCRIPTION
## Motivation

After recent addition of sync module the jacoco report generation must be fixed

## Description

jacoco.gradle applied for sync. This way all the modules (auth, core, push, security, sync) has `jacocoTestReport` task.

Updated `jacocoRootReport` task so as not to fail if there are data missing. Data are missing for sync because there are no unit tests implemented.

Task `createDebugCoverageReport` has been removed due to #278. This is due to this task being dependent on `processDebugAndroidTestManifest` and this task no longer work for auth module. It has no effect on code coverage generated.

## Additional information

Once this is merged, I will proceed with https://github.com/aerogear/aerogear-android-sdk/pull/284 where currently the checks failed.

## Progress

- [x] Done Task
- [ ] Todo Task
