### PR TITLE
Renamed getFreshUser to getCurrentUser(boolean autorefresh)

### DIFF
--- a/auth/src/main/java/org/aerogear/mobile/auth/AuthHeaderProvider.java
+++ b/auth/src/main/java/org/aerogear/mobile/auth/AuthHeaderProvider.java
@@ -27,7 +27,7 @@ public class AuthHeaderProvider implements HeaderProvider {
      */
     @Override
     public Map<String, String> getHeaders() {
-        UserPrincipal user = authService.getFreshCurrentUser();
+        UserPrincipal user = authService.getCurrentUser(true);
         if (user != null && user.getAccessToken() != null) {
             String accessToken = user.getAccessToken();
             return Collections.singletonMap(HEADER_KEY, HEADER_TYPE + accessToken);


### PR DESCRIPTION
## Motivation

Both `getFreshUser` and `getCurrentUser` returns the current logged in user. The difference is that the `getFreshUser` automatically refresh the token if needed.

Instead of duplicating code, this PR changes it to a parameter.

Moreover, this PR make android code coherent with what we have in the other platforms (iOS and Xamarin)